### PR TITLE
Adapt pipeline to new transaction schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ from coi_fraud import run_pipeline
 from coi_fraud.viz import plots
 from coi_fraud.analysis import qa
 
-df = pd.read_csv("/content/mis_transacciones.csv")  # columnas: persona_1, persona_2, relacion, fecha_hora, monto, descripcion
+df = pd.read_csv("/content/mis_transacciones.csv")  # columnas mínimas: user_id, receptor-user_id, load_date, movement_amount, transaction_desc
 reports = run_pipeline(df)
 
 # gráficos

--- a/coi_fraud/aggregate/concepts.py
+++ b/coi_fraud/aggregate/concepts.py
@@ -1,22 +1,37 @@
-
 import pandas as pd
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 def build_concept_tables(df: pd.DataFrame):
     tx = df.copy()
-    txc = tx[tx["nlp_concepto_sospechoso"]!=""].copy()
-    agg_concepto = (txc.groupby(["month_id","nlp_concepto_sospechoso"], observed=True)
-        .agg(tx_count=("monto","count"),
-             tx_sum=("monto","sum"),
-             emisores_unicos=("persona_1","nunique"),
-             receptores_unicos=("persona_2","nunique"),
-             risk_avg=("risk_score","mean"),
-             risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0))
+    txc = tx[tx["nlp_concepto_sospechoso"] != ""].copy()
+    agg_concepto = (
+        txc.groupby(["month_id", "nlp_concepto_sospechoso"], observed=True)
+        .agg(
+            tx_count=(COL_AMOUNT, "count"),
+            tx_sum=(COL_AMOUNT, "sum"),
+            emisores_unicos=(COL_SENDER_ID, "nunique"),
+            receptores_unicos=(COL_RECEIVER_ID, "nunique"),
+            risk_avg=("risk_score", "mean"),
+            risk_p95=(
+                "risk_score",
+                lambda s: float(s.quantile(0.95)) if len(s) else 0.0,
+            ),
+        )
         .reset_index()
-        .sort_values(["month_id","risk_p95","tx_count"], ascending=[True,False,False]))
-    agg_persona_concepto = (txc.groupby(["month_id","persona_1","nlp_concepto_sospechoso"], observed=True)
-        .agg(tx_count=("monto","count"), tx_sum=("monto","sum"), risk_avg=("risk_score","mean"))
-        .reset_index().rename(columns={"persona_1":"persona"}))
-    txc["pair"] = txc["persona_1"].astype(str)+"→"+txc["persona_2"].astype(str)
-    agg_par_concepto = (txc.groupby(["month_id","pair","nlp_concepto_sospechoso"], observed=True)
-        .agg(tx_count=("monto","count"), tx_sum=("monto","sum"), risk_avg=("risk_score","mean"))
-        .reset_index())
+        .sort_values(["month_id", "risk_p95", "tx_count"], ascending=[True, False, False])
+    )
+    agg_persona_concepto = (
+        txc.groupby(["month_id", COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)
+        .agg(tx_count=(COL_AMOUNT, "count"), tx_sum=(COL_AMOUNT, "sum"), risk_avg=("risk_score", "mean"))
+        .reset_index()
+        .rename(columns={COL_SENDER_ID: "persona"})
+    )
+    txc["pair"] = txc[COL_SENDER_ID].astype(str) + "→" + txc[COL_RECEIVER_ID].astype(str)
+    agg_par_concepto = (
+        txc.groupby(["month_id", "pair", "nlp_concepto_sospechoso"], observed=True)
+        .agg(tx_count=(COL_AMOUNT, "count"), tx_sum=(COL_AMOUNT, "sum"), risk_avg=("risk_score", "mean"))
+        .reset_index()
+    )
     return agg_concepto, agg_persona_concepto, agg_par_concepto

--- a/coi_fraud/aggregate/pairs.py
+++ b/coi_fraud/aggregate/pairs.py
@@ -1,27 +1,43 @@
-
 import pandas as pd
+
 from ..interpret.pair import pair_interpretation
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
     tmp = df.copy()
-    tmp["pair"] = tmp["persona_1"].astype(str) + "→" + tmp["persona_2"].astype(str)
-    agg = (tmp.groupby(["month_id","pair"], observed=True)
-        .agg(tx_count=("monto","count"),
-             tx_sum=("monto","sum"),
-             risk_max=("risk_score","max"),
-             risk_avg=("risk_score","mean"),
-             pct_yoyo=("sig_yoyo","mean"),
-             pct_smurf=("sig_smurf","mean"),
-             pct_freq=("sig_freq","mean"),
-             pct_recurrent=("sig_recurrent","mean"))
-        .reset_index())
-    topc = (tmp[tmp["nlp_concepto_sospechoso"]!=""]
-            .groupby(["month_id","pair","nlp_concepto_sospechoso"], observed=True)["monto"]
-            .count().reset_index(name="cnt"))
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    agg = (
+        tmp.groupby(["month_id", "pair"], observed=True)
+        .agg(
+            tx_count=(COL_AMOUNT, "count"),
+            tx_sum=(COL_AMOUNT, "sum"),
+            risk_max=("risk_score", "max"),
+            risk_avg=("risk_score", "mean"),
+            pct_yoyo=("sig_yoyo", "mean"),
+            pct_smurf=("sig_smurf", "mean"),
+            pct_freq=("sig_freq", "mean"),
+            pct_recurrent=("sig_recurrent", "mean"),
+        )
+        .reset_index()
+    )
+    topc = (
+        tmp[tmp["nlp_concepto_sospechoso"] != ""]
+        .groupby(["month_id", "pair", "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
+        .count()
+        .reset_index(name="cnt")
+    )
     if len(topc):
-        topc = topc.sort_values(["month_id","pair","cnt"], ascending=[True,True,False]).groupby(["month_id","pair"]).head(3)
-        tops = topc.groupby(["month_id","pair"])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
-        agg = agg.merge(tops, on=["month_id","pair"], how="left")
+        topc = (
+            topc.sort_values(["month_id", "pair", "cnt"], ascending=[True, True, False])
+            .groupby(["month_id", "pair"])
+            .head(3)
+        )
+        tops = (
+            topc.groupby(["month_id", "pair"])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
+        )
+        agg = agg.merge(tops, on=["month_id", "pair"], how="left")
     else:
         agg["top_conceptos"] = [[] for _ in range(len(agg))]
     agg["interp_pair"] = agg.apply(pair_interpretation, axis=1)
-    return agg.sort_values(["risk_max","tx_sum"], ascending=[False,False])
+    return agg.sort_values(["risk_max", "tx_sum"], ascending=[False, False])

--- a/coi_fraud/aggregate/persons.py
+++ b/coi_fraud/aggregate/persons.py
@@ -1,26 +1,69 @@
-
 import pandas as pd
+
 from ..interpret.person import person_interpretation
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
-    em = (df.groupby(["month_id","persona_1"], observed=True)
-             .agg(n_tx_emit=("monto","count"), sum_emit=("monto","sum"), avg_emit=("monto","mean"),
-                  risk_avg_em=("risk_score","mean"), risk_max_emit=("risk_score","max"))
-             .rename_axis(index={"persona_1":"persona"}).reset_index())
-    re = (df.groupby(["month_id","persona_2"], observed=True)
-             .agg(n_tx_recv=("monto","count"), sum_recv=("monto","sum"), avg_recv=("monto","mean"),
-                  risk_avg_re=("risk_score","mean"), risk_max_recv=("risk_score","max"))
-             .rename_axis(index={"persona_2":"persona"}).reset_index())
-    people = pd.merge(em, re, on=["month_id","persona"], how="outer").fillna(
-        {"n_tx_emit":0,"sum_emit":0.0,"avg_emit":0.0,"risk_avg_em":0.0,"risk_max_emit":0.0,
-         "n_tx_recv":0,"sum_recv":0.0,"avg_recv":0.0,"risk_avg_re":0.0,"risk_max_recv":0.0}
+    em = (
+        df.groupby(["month_id", COL_SENDER_ID], observed=True)
+        .agg(
+            n_tx_emit=(COL_AMOUNT, "count"),
+            sum_emit=(COL_AMOUNT, "sum"),
+            avg_emit=(COL_AMOUNT, "mean"),
+            risk_avg_em=("risk_score", "mean"),
+            risk_max_emit=("risk_score", "max"),
+        )
+        .rename_axis(index={COL_SENDER_ID: "persona"})
+        .reset_index()
+    )
+    re = (
+        df.groupby(["month_id", COL_RECEIVER_ID], observed=True)
+        .agg(
+            n_tx_recv=(COL_AMOUNT, "count"),
+            sum_recv=(COL_AMOUNT, "sum"),
+            avg_recv=(COL_AMOUNT, "mean"),
+            risk_avg_re=("risk_score", "mean"),
+            risk_max_recv=("risk_score", "max"),
+        )
+        .rename_axis(index={COL_RECEIVER_ID: "persona"})
+        .reset_index()
+    )
+    people = pd.merge(em, re, on=["month_id", "persona"], how="outer").fillna(
+        {
+            "n_tx_emit": 0,
+            "sum_emit": 0.0,
+            "avg_emit": 0.0,
+            "risk_avg_em": 0.0,
+            "risk_max_emit": 0.0,
+            "n_tx_recv": 0,
+            "sum_recv": 0.0,
+            "avg_recv": 0.0,
+            "risk_avg_re": 0.0,
+            "risk_max_recv": 0.0,
+        }
     )
     people["risk_avg_person"] = (people["risk_avg_em"] + people["risk_avg_re"]) / 2.0
-    topc = (df[df["nlp_concepto_sospechoso"]!=""]
-            .groupby(["month_id","persona_1","nlp_concepto_sospechoso"], observed=True)["monto"]
-            .count().reset_index(name="cnt"))
-    topc = topc.sort_values(["month_id","persona_1","cnt"], ascending=[True,True,False]).groupby(["month_id","persona_1"]).head(3)
-    tops = topc.groupby(["month_id","persona_1"])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
-    people = people.merge(tops, left_on=["month_id","persona"], right_on=["month_id","persona_1"], how="left").drop(columns=["persona_1"], errors="ignore")
-    people["top_conceptos"] = people["top_conceptos"].apply(lambda x: x if isinstance(x,list) else [])
+    topc = (
+        df[df["nlp_concepto_sospechoso"] != ""]
+        .groupby(["month_id", COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
+        .count()
+        .reset_index(name="cnt")
+    )
+    topc = (
+        topc.sort_values(["month_id", COL_SENDER_ID, "cnt"], ascending=[True, True, False])
+        .groupby(["month_id", COL_SENDER_ID])
+        .head(3)
+    )
+    tops = (
+        topc.groupby(["month_id", COL_SENDER_ID])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
+    )
+    people = people.merge(
+        tops,
+        left_on=["month_id", "persona"],
+        right_on=["month_id", COL_SENDER_ID],
+        how="left",
+    ).drop(columns=[COL_SENDER_ID], errors="ignore")
+    people["top_conceptos"] = people["top_conceptos"].apply(lambda x: x if isinstance(x, list) else [])
     people["interp_person"] = people.apply(person_interpretation, axis=1)
-    return people.sort_values(["risk_avg_person","sum_emit","sum_recv"], ascending=[False,False,False])
+    return people.sort_values(["risk_avg_person", "sum_emit", "sum_recv"], ascending=[False, False, False])

--- a/coi_fraud/analysis/qa.py
+++ b/coi_fraud/analysis/qa.py
@@ -1,71 +1,160 @@
+import re
 
-import re, pandas as pd
+import pandas as pd
+
+from ..schemas import (
+    COL_AMOUNT,
+    COL_DESCRIPTION,
+    COL_RECEIVER_ID,
+    COL_RELATION,
+    COL_SENDER_ID,
+)
+
+
 def empleados_recepcion_constante(reports, min_meses=3):
-    d = reports["agg_par_mensual"][["month_id","pair","tx_count","pct_recurrent"]].copy()
-    out = (d.assign(tiene_tx=d["tx_count"]>0, tiene_rec=d["pct_recurrent"]>0)
-             .groupby("pair", as_index=False)
-             .agg(meses_con_tx=("tiene_tx","sum"), meses_recurrente=("tiene_rec","sum"))
-             .query("meses_con_tx >= @min_meses")
-             .sort_values(["meses_recurrente","meses_con_tx"], ascending=[False,False]))
+    d = reports["agg_par_mensual"][
+        ["month_id", "pair", "tx_count", "pct_recurrent"]
+    ].copy()
+    out = (
+        d.assign(tiene_tx=d["tx_count"] > 0, tiene_rec=d["pct_recurrent"] > 0)
+        .groupby("pair", as_index=False)
+        .agg(
+            meses_con_tx=("tiene_tx", "sum"),
+            meses_recurrente=("tiene_rec", "sum"),
+        )
+        .query("meses_con_tx >= @min_meses")
+        .sort_values(["meses_recurrente", "meses_con_tx"], ascending=[False, False])
+    )
     return out
+
 
 def desbalance_personas(reports):
     pers = reports["agg_persona_mensual"].copy()
-    desbalance = (pers.assign(net=pers["sum_emit"]-pers["sum_recv"], ratio=(pers["sum_emit"]/(pers["sum_recv"]+1e-9)))
-                     .sort_values(["month_id","net"], ascending=[True, False]))
+    desbalance = (
+        pers.assign(
+            net=pers["sum_emit"] - pers["sum_recv"],
+            ratio=(pers["sum_emit"] / (pers["sum_recv"] + 1e-9)),
+        )
+        .sort_values(["month_id", "net"], ascending=[True, False])
+    )
     return desbalance
+
 
 def manager_conceptos_sospechosos(reports, keywords=None):
     tx = reports["tx_transacciones_priorizadas"].copy()
-    mgr = tx[tx["relacion"].str.contains("Manager", case=False, na=False)]
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
     if keywords:
         pat = re.compile("|".join([re.escape(k) for k in keywords]), re.IGNORECASE)
-        mgr = mgr[mgr["descripcion"].fillna("").str.contains(pat)]
-    agg = (mgr.groupby(["month_id","nlp_concepto_sospechoso"], as_index=False)
-           .agg(tx_count=("risk_score","count"),
-                risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0))
-           .sort_values(["month_id","risk_p95","tx_count"], ascending=[True,False,False]))
+        mgr = mgr[mgr[COL_DESCRIPTION].fillna("").str.contains(pat)]
+    agg = (
+        mgr.groupby(["month_id", "nlp_concepto_sospechoso"], as_index=False)
+        .agg(
+            tx_count=("risk_score", "count"),
+            risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0),
+        )
+        .sort_values(["month_id", "risk_p95", "tx_count"], ascending=[True, False, False])
+    )
     return agg
 
+
 def centralizadores(reports):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","monto","risk_score"]].copy()
-    centro = (tx.groupby(["month_id","persona_2"], as_index=False)
-        .agg(inflow=("monto","sum"), emisores_unicos=("persona_1","nunique"), n_tx=("monto","count"), risk_avg=("risk_score","mean"))
-        .assign(centralidad=lambda d: d["inflow"]*d["emisores_unicos"])
-        .sort_values(["month_id","centralidad"], ascending=[True,False]))
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, COL_AMOUNT, "risk_score"]
+    ].copy()
+    centro = (
+        tx.groupby(["month_id", COL_RECEIVER_ID], as_index=False)
+        .agg(
+            inflow=(COL_AMOUNT, "sum"),
+            emisores_unicos=(COL_SENDER_ID, "nunique"),
+            n_tx=(COL_AMOUNT, "count"),
+            risk_avg=("risk_score", "mean"),
+        )
+        .assign(centralidad=lambda d: d["inflow"] * d["emisores_unicos"])
+        .sort_values(["month_id", "centralidad"], ascending=[True, False])
+    )
     return centro
 
+
 def yoyo_consecutivos(reports):
-    par = reports["agg_par_mensual"][["month_id","pair","pct_yoyo"]].copy()
+    par = reports["agg_par_mensual"][
+        ["month_id", "pair", "pct_yoyo"]
+    ].copy()
     par["hit"] = par["pct_yoyo"] > 0
-    out = (par.sort_values(["pair","month_id"]).groupby("pair")["hit"].apply(lambda s: any(s.shift(1).fillna(False) & s)).reset_index(name="tiene_racha_yo_yo"))
+    out = (
+        par.sort_values(["pair", "month_id"])
+        .groupby("pair")["hit"]
+        .apply(lambda s: any(s.shift(1).fillna(False) & s))
+        .reset_index(name="tiene_racha_yo_yo")
+    )
     return out[out["tiene_racha_yo_yo"]]
 
+
 def near_thr_repetido(reports, min_meses=2):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","sig_near_thr"]].copy()
-    tx["pair"] = tx["persona_1"] + "→" + tx["persona_2"]
-    near = tx.groupby(["pair","month_id"], as_index=False)["sig_near_thr"].mean().assign(hit=lambda d: d["sig_near_thr"]>0)
-    rep = near.groupby("pair", as_index=False)["hit"].sum().rename(columns={"hit":"meses_con_near"}).query("meses_con_near >= @min_meses").sort_values("meses_con_near", ascending=False)
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]
+    ].copy()
+    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+    near = (
+        tx.groupby(["pair", "month_id"], as_index=False)["sig_near_thr"]
+        .mean()
+        .assign(hit=lambda d: d["sig_near_thr"] > 0)
+    )
+    rep = (
+        near.groupby("pair", as_index=False)["hit"]
+        .sum()
+        .rename(columns={"hit": "meses_con_near"})
+        .query("meses_con_near >= @min_meses")
+        .sort_values("meses_con_near", ascending=False)
+    )
     return rep
 
+
 def manager_conceptos_riesgo(reports):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","relacion","nlp_concepto_sospechoso","risk_score"]].copy()
-    mgr = tx[tx["relacion"].str.contains("Manager", case=False, na=False)]
-    top = (mgr.groupby(["month_id","nlp_concepto_sospechoso"], as_index=False)
-         .agg(tx_count=("risk_score","count"), risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0))
-         .sort_values(["month_id","risk_p95","tx_count"], ascending=[True, False, False]))
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_RELATION, "nlp_concepto_sospechoso", "risk_score"]
+    ].copy()
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
+    top = (
+        mgr.groupby(["month_id", "nlp_concepto_sospechoso"], as_index=False)
+        .agg(
+            tx_count=("risk_score", "count"),
+            risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0),
+        )
+        .sort_values(["month_id", "risk_p95", "tx_count"], ascending=[True, False, False])
+    )
     return top
 
+
 def prestamos_freq_dos_meses(reports, min_meses=2):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","sig_loan_bad_repay","sig_freq"]].copy()
-    tx["pair"] = tx["persona_1"] + "→" + tx["persona_2"]
-    mes_flag = (tx.groupby(["pair","month_id"], as_index=False)
-                  .agg(loan_bad=("sig_loan_bad_repay","max"), freq=("sig_freq","mean"))
-                  .assign(hit=lambda d: d["loan_bad"] & (d["freq"]>0)))
-    candidatos = mes_flag.groupby("pair", as_index=False)["hit"].sum().rename(columns={"hit":"meses_condicion"}).query("meses_condicion >= @min_meses").sort_values("meses_condicion", ascending=False)
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]
+    ].copy()
+    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+    mes_flag = (
+        tx.groupby(["pair", "month_id"], as_index=False)
+        .agg(loan_bad=("sig_loan_bad_repay", "max"), freq=("sig_freq", "mean"))
+        .assign(hit=lambda d: d["loan_bad"] & (d["freq"] > 0))
+    )
+    candidatos = (
+        mes_flag.groupby("pair", as_index=False)["hit"]
+        .sum()
+        .rename(columns={"hit": "meses_condicion"})
+        .query("meses_condicion >= @min_meses")
+        .sort_values("meses_condicion", ascending=False)
+    )
     return candidatos
 
+
 def smurf_cronico(reports, min_meses=3):
-    par = reports["agg_par_mensual"][["pair","month_id","pct_smurf"]].copy()
-    cron = (par.assign(hit=par["pct_smurf"]>0).groupby("pair", as_index=False)["hit"].sum().rename(columns={"hit":"meses_smurf"}).query("meses_smurf >= @min_meses").sort_values("meses_smurf", ascending=False))
+    par = reports["agg_par_mensual"][
+        ["pair", "month_id", "pct_smurf"]
+    ].copy()
+    cron = (
+        par.assign(hit=par["pct_smurf"] > 0)
+        .groupby("pair", as_index=False)["hit"]
+        .sum()
+        .rename(columns={"hit": "meses_smurf"})
+        .query("meses_smurf >= @min_meses")
+        .sort_values("meses_smurf", ascending=False)
+    )
     return cron

--- a/coi_fraud/features/baselines.py
+++ b/coi_fraud/features/baselines.py
@@ -1,11 +1,14 @@
-
 import pandas as pd
+
+from ..schemas import COL_AMOUNT, COL_SENDER_ID
+
+
 class Baselines:
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        g = df.groupby("persona_1", observed=True)["monto"]
+        g = df.groupby(COL_SENDER_ID, observed=True)[COL_AMOUNT]
         mean = g.transform("mean")
         std = g.transform("std").fillna(1.0)
         df["feat_avg_monto_emisor"] = mean
         df["feat_std_monto_emisor"] = std
-        df["feat_zscore_monto"] = (df["monto"] - mean) / std
+        df["feat_zscore_monto"] = (df[COL_AMOUNT] - mean) / std
         return df

--- a/coi_fraud/features/description.py
+++ b/coi_fraud/features/description.py
@@ -1,28 +1,42 @@
-
 import re
+
 import pandas as pd
+
+from ..schemas import COL_DESCRIPTION
 from ..utils.text import normalize_text
+
 
 class DescriptionAnalyzer:
     def __init__(self, emo_phrases=None, regex_families=None):
-        self.emo = [normalize_text(x) for x in (emo_phrases or ["gracias mil","favorzote","te debo la vida","eres el mejor"])]
-        self.rex = {k: re.compile(v) for k,v in (regex_families or {
-            "PRESTAMO": r"\b(?:prestam|adelant|deuda|abono)\b",
-            "VAGUEDAD": r"\b(?:varios|gastos|servicio|pago|consultoria|apoyo|reembolso|proyecto)\b"
-        }).items()}
+        self.emo = [
+            normalize_text(x)
+            for x in (emo_phrases or ["gracias mil", "favorzote", "te debo la vida", "eres el mejor"])
+        ]
+        self.rex = {
+            k: re.compile(v)
+            for k, v in (
+                regex_families
+                or {
+                    "PRESTAMO": r"\b(?:prestam|adelant|deuda|abono)\b",
+                    "VAGUEDAD": r"\b(?:varios|gastos|servicio|pago|consultoria|apoyo|reembolso|proyecto)\b",
+                }
+            ).items()
+        }
 
     def transform(self, df: pd.DataFrame) -> pd.DataFrame:
-        dn = df["descripcion"].fillna("").map(normalize_text)
-        vag=[]; emo=[]; flags=[]
+        dn = df[COL_DESCRIPTION].fillna("").map(normalize_text)
+        vag = []
+        emo = []
+        flags = []
         for s in dn.tolist():
             toks = s.split()
             vag_hits = len(re.findall(self.rex.get("VAGUEDAD", re.compile("a^")), s))
-            v = (vag_hits / max(1,len(toks))) if len(toks)>2 else max(0.8, vag_hits / max(1,len(toks)))
+            v = (vag_hits / max(1, len(toks))) if len(toks) > 2 else max(0.8, vag_hits / max(1, len(toks)))
             vag.append(float(v))
             emo.append(float(sum(1 for p in self.emo if p in s)))
-            fams=[fam for fam, rx in self.rex.items() if rx.search(s)]
+            fams = [fam for fam, rx in self.rex.items() if rx.search(s)]
             flags.append(sorted(set(fams)) if fams else ([] if s else ["SIN_DESCRIPCION"]))
-        df["feat_nlp_vaguedad"]=vag
-        df["feat_nlp_emocion"]=emo
-        df["desc_flags"]=flags
+        df["feat_nlp_vaguedad"] = vag
+        df["feat_nlp_emocion"] = emo
+        df["desc_flags"] = flags
         return df

--- a/coi_fraud/features/frequency.py
+++ b/coi_fraud/features/frequency.py
@@ -1,24 +1,35 @@
-
 from datetime import timedelta
 from collections import defaultdict
+
+from ..schemas import COL_RECEIVER_ID, COL_SENDER_ID
+
+
 class FrequencyDetector:
     def __init__(self, window_days, min_cnt):
-        self.win = timedelta(days=window_days); self.min_cnt=min_cnt
+        self.win = timedelta(days=window_days)
+        self.min_cnt = min_cnt
+
     def transform(self, df):
-        df = df.sort_values(["persona_1","persona_2","fecha_hora_ts"]).reset_index(drop=True)
-        flags=[False]*len(df)
+        df = df.sort_values([COL_SENDER_ID, COL_RECEIVER_ID, "fecha_hora_ts"]).reset_index(drop=True)
+        flags = [False] * len(df)
         idxs_by_pair = defaultdict(list)
-        for i,(a,b) in enumerate(zip(df["persona_1"], df["persona_2"])):
-            idxs_by_pair[(a,b)].append(i)
-        for (a,b), idxs in idxs_by_pair.items():
-            times=df.loc[idxs,"fecha_hora_ts"].tolist(); n=len(idxs); i=0; diff=[0]*(n+1)
+        for i, (a, b) in enumerate(zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID])):
+            idxs_by_pair[(a, b)].append(i)
+        for (a, b), idxs in idxs_by_pair.items():
+            times = df.loc[idxs, "fecha_hora_ts"].tolist()
+            n = len(idxs)
+            i = 0
+            diff = [0] * (n + 1)
             for j in range(n):
-                while times[j] - times[i] > self.win: i+=1
+                while times[j] - times[i] > self.win:
+                    i += 1
                 if (j - i + 1) >= self.min_cnt:
-                    diff[i]+=1; diff[j+1]-=1
-            acc=0
+                    diff[i] += 1
+                    diff[j + 1] -= 1
+            acc = 0
             for k in range(n):
-                acc+=diff[k]
-                if acc>0: flags[idxs[k]]=True
-        df["sig_freq"]=flags
+                acc += diff[k]
+                if acc > 0:
+                    flags[idxs[k]] = True
+        df["sig_freq"] = flags
         return df

--- a/coi_fraud/features/loan.py
+++ b/coi_fraud/features/loan.py
@@ -1,26 +1,37 @@
-
 from datetime import timedelta
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID, COL_DESCRIPTION
 from ..utils.text import normalize_text
+
+
 class LoanRepayDetector:
     def __init__(self, days, min_ratio):
-        self.days=days; self.min_ratio=min_ratio
+        self.days = days
+        self.min_ratio = min_ratio
+
     def transform(self, df):
-        is_loan = df["descripcion"].fillna("").map(normalize_text).str.contains(r"\b(prestam|adelant|abono)\b", regex=True)
-        df["sig_loan_like"]=is_loan
-        df["sig_loan_bad_repay"]=False
-        df["feat_repay_ratio"]=1.0
+        is_loan = df[COL_DESCRIPTION].fillna("").map(normalize_text).str.contains(
+            r"\b(prestam|adelant|abono)\b", regex=True
+        )
+        df["sig_loan_like"] = is_loan
+        df["sig_loan_bad_repay"] = False
+        df["feat_repay_ratio"] = 1.0
         ba_index = {}
-        for i,(a,b) in enumerate(zip(df["persona_1"], df["persona_2"])):
-            ba_index.setdefault((b,a), []).append(i)
+        for i, (a, b) in enumerate(zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID])):
+            ba_index.setdefault((b, a), []).append(i)
         for i in df.index[df["sig_loan_like"]].tolist():
-            a=df.at[i,"persona_1"]; b=df.at[i,"persona_2"]
-            t0=df.at[i,"fecha_hora_ts"]; loan=float(df.at[i,"monto"])
+            a = df.at[i, COL_SENDER_ID]
+            b = df.at[i, COL_RECEIVER_ID]
+            t0 = df.at[i, "fecha_hora_ts"]
+            loan = float(df.at[i, COL_AMOUNT])
             wend = t0 + timedelta(days=self.days)
-            repay_sum=0.0
-            for j in ba_index.get((a,b),[]):
-                t1=df.at[j,"fecha_hora_ts"]
-                if t0 <= t1 <= wend: repay_sum += float(df.at[j,"monto"])
-            ratio = (repay_sum/loan) if loan>0 else 1.0
-            df.at[i,"feat_repay_ratio"]=ratio
-            if ratio < self.min_ratio: df.at[i,"sig_loan_bad_repay"]=True
+            repay_sum = 0.0
+            for j in ba_index.get((a, b), []):
+                t1 = df.at[j, "fecha_hora_ts"]
+                if t0 <= t1 <= wend:
+                    repay_sum += float(df.at[j, COL_AMOUNT])
+            ratio = (repay_sum / loan) if loan > 0 else 1.0
+            df.at[i, "feat_repay_ratio"] = ratio
+            if ratio < self.min_ratio:
+                df.at[i, "sig_loan_bad_repay"] = True
         return df

--- a/coi_fraud/features/near_threshold.py
+++ b/coi_fraud/features/near_threshold.py
@@ -1,12 +1,18 @@
+from ..schemas import COL_AMOUNT
+
 
 class NearThresholdDetector:
     def __init__(self, thresholds, delta):
-        self.thrs = thresholds; self.delta = delta
+        self.thrs = thresholds
+        self.delta = delta
+
     def transform(self, df):
         def f(x):
-            ds=[abs(x-t) for t in self.thrs]; m=min(ds) if ds else 1e9
-            return (m<=self.delta, m)
-        vals = df["monto"].apply(f)
+            ds = [abs(x - t) for t in self.thrs]
+            m = min(ds) if ds else 1e9
+            return (m <= self.delta, m)
+
+        vals = df[COL_AMOUNT].apply(f)
         df["sig_near_thr"] = vals.apply(lambda v: v[0])
         df["feat_delta_near_thr"] = vals.apply(lambda v: v[1])
         return df

--- a/coi_fraud/features/nlp_mx.py
+++ b/coi_fraud/features/nlp_mx.py
@@ -1,8 +1,16 @@
-
 import pandas as pd
+
+from ..schemas import COL_DESCRIPTION, COL_RELATION
 from .nlp_mx_impl import nlp_mx_etiquetar_transacciones_pro
+
+
 def apply_nlp(df: pd.DataFrame) -> pd.DataFrame:
-    out = nlp_mx_etiquetar_transacciones_pro(df, col_texto="descripcion", col_relacion="relacion", use_embeddings=True)
+    out = nlp_mx_etiquetar_transacciones_pro(
+        df,
+        col_texto=COL_DESCRIPTION,
+        col_relacion=COL_RELATION,
+        use_embeddings=True,
+    )
     df2 = df.copy()
     df2["nlp_concepto_sospechoso"] = out["concepto sospechoso"]
     df2["feat_nlp_risk_points"] = out["riesgo_puntos"]

--- a/coi_fraud/features/recurrent.py
+++ b/coi_fraud/features/recurrent.py
@@ -1,14 +1,21 @@
+from ..schemas import COL_RECEIVER_ID, COL_SENDER_ID
+
 
 class MonthlyRecurrentDetector:
     def __init__(self, months_min):
         self.min_months = months_min
+
     def transform(self, df):
         df = df.copy()
         df["dom"] = df["fecha_hora_ts"].dt.day
         dt_naive = df["fecha_hora_ts"].dt.tz_convert(None)
         df["ym"] = dt_naive.dt.to_period("M").astype(str)
-        g = (df.groupby(["persona_1","persona_2","dom"], observed=True)["ym"]
-               .nunique().reset_index().rename(columns={"ym":"months"}))
-        df = df.merge(g, on=["persona_1","persona_2","dom"], how="left")
+        g = (
+            df.groupby([COL_SENDER_ID, COL_RECEIVER_ID, "dom"], observed=True)["ym"]
+            .nunique()
+            .reset_index()
+            .rename(columns={"ym": "months"})
+        )
+        df = df.merge(g, on=[COL_SENDER_ID, COL_RECEIVER_ID, "dom"], how="left")
         df["sig_recurrent"] = df["months"] >= self.min_months
-        return df.drop(columns=["dom","ym","months"])
+        return df.drop(columns=["dom", "ym", "months"])

--- a/coi_fraud/features/roundsum.py
+++ b/coi_fraud/features/roundsum.py
@@ -1,12 +1,17 @@
+from ..schemas import COL_AMOUNT
+
 
 class RoundSumDetector:
     def __init__(self, bases):
         self.bases = bases
+
     def transform(self, df):
-        def is_round(x: float)->bool:
+        def is_round(x: float) -> bool:
             for b in self.bases:
                 r = x % b
-                if r < 1e-9 or abs(b - r) < 1e-9: return True
+                if r < 1e-9 or abs(b - r) < 1e-9:
+                    return True
             return False
-        df["sig_roundsum"] = df["monto"].apply(is_round)
+
+        df["sig_roundsum"] = df[COL_AMOUNT].apply(is_round)
         return df

--- a/coi_fraud/features/smurf.py
+++ b/coi_fraud/features/smurf.py
@@ -1,34 +1,48 @@
-
 from collections import defaultdict, deque
 from datetime import timedelta
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 class SmurfingDetector:
     def __init__(self, window_days, thresholds):
-        self.win = timedelta(days=window_days); self.thrs = thresholds
+        self.win = timedelta(days=window_days)
+        self.thrs = thresholds
+
     def transform(self, df):
-        df = df.sort_values(["persona_1","persona_2","fecha_hora_ts"]).reset_index(drop=True)
-        flags = [False]*len(df)
+        df = df.sort_values([COL_SENDER_ID, COL_RECEIVER_ID, "fecha_hora_ts"]).reset_index(drop=True)
+        flags = [False] * len(df)
         idxs_by_pair = defaultdict(list)
-        for i,(a,b) in enumerate(zip(df["persona_1"], df["persona_2"])):
-            idxs_by_pair[(a,b)].append(i)
-        for (a,b), idxs in idxs_by_pair.items():
-            times = df.loc[idxs,"fecha_hora_ts"].tolist()
-            amts  = df.loc[idxs,"monto"].tolist()
-            n=len(idxs); i=0; sumw=0.0; diff=[0]*(n+1); maxdq=deque()
+        for i, (a, b) in enumerate(zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID])):
+            idxs_by_pair[(a, b)].append(i)
+        for (a, b), idxs in idxs_by_pair.items():
+            times = df.loc[idxs, "fecha_hora_ts"].tolist()
+            amts = df.loc[idxs, COL_AMOUNT].tolist()
+            n = len(idxs)
+            i = 0
+            sumw = 0.0
+            diff = [0] * (n + 1)
+            maxdq = deque()
             for j in range(n):
-                t=times[j]; x=amts[j]
+                t = times[j]
+                x = amts[j]
                 sumw += x
-                while maxdq and maxdq[-1][1] <= x: maxdq.pop()
-                maxdq.append((j,x))
+                while maxdq and maxdq[-1][1] <= x:
+                    maxdq.pop()
+                maxdq.append((j, x))
                 while t - times[i] > self.win:
                     sumw -= amts[i]
-                    if maxdq and maxdq[0][0]==i: maxdq.popleft()
-                    i+=1
+                    if maxdq and maxdq[0][0] == i:
+                        maxdq.popleft()
+                    i += 1
                 maxv = maxdq[0][1] if maxdq else 0.0
-                if any(sumw>=thr and maxv<thr for thr in self.thrs):
-                    diff[i]+=1; diff[j+1]-=1
-            acc=0
+                if any(sumw >= thr and maxv < thr for thr in self.thrs):
+                    diff[i] += 1
+                    diff[j + 1] -= 1
+            acc = 0
             for k in range(n):
-                acc+=diff[k]
-                if acc>0: flags[idxs[k]] = True
+                acc += diff[k]
+                if acc > 0:
+                    flags[idxs[k]] = True
         df["sig_smurf"] = flags
         return df

--- a/coi_fraud/features/yoyo.py
+++ b/coi_fraud/features/yoyo.py
@@ -1,32 +1,43 @@
-
 from collections import defaultdict
 from datetime import timedelta
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 class YoYoDetector:
     def __init__(self, hours, tol):
-        self.hwin = timedelta(hours=hours); self.tol=tol
+        self.hwin = timedelta(hours=hours)
+        self.tol = tol
+
     def transform(self, df):
         df = df.sort_values("fecha_hora_ts").reset_index(drop=True)
-        flag=[False]*len(df)
+        flag = [False] * len(df)
         bucket = defaultdict(list)
-        for i,(a,b) in enumerate(zip(df["persona_1"], df["persona_2"])):
-            key = (a,b) if a<=b else (b,a)
+        for i, (a, b) in enumerate(zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID])):
+            key = (a, b) if a <= b else (b, a)
             bucket[key].append(i)
         for key, idxs in bucket.items():
-            AtoB=[]; BtoA=[]
+            AtoB = []
+            BtoA = []
             for i in idxs:
-                a,b,t,x = df.loc[i,["persona_1","persona_2","fecha_hora_ts","monto"]]
-                if key==(a,b): AtoB.append((t,x,i))
-                else: BtoA.append((t,x,i))
-            AtoB.sort(); BtoA.sort()
-            j=0
-            for t1,x1,i1 in AtoB:
-                while j < len(BtoA) and BtoA[j][0] < t1 - self.hwin: j+=1
-                k=j
+                a, b, t, x = df.loc[i, [COL_SENDER_ID, COL_RECEIVER_ID, "fecha_hora_ts", COL_AMOUNT]]
+                if key == (a, b):
+                    AtoB.append((t, x, i))
+                else:
+                    BtoA.append((t, x, i))
+            AtoB.sort()
+            BtoA.sort()
+            j = 0
+            for t1, x1, i1 in AtoB:
+                while j < len(BtoA) and BtoA[j][0] < t1 - self.hwin:
+                    j += 1
+                k = j
                 while k < len(BtoA) and BtoA[k][0] <= t1 + self.hwin:
-                    t2,x2,i2 = BtoA[k]
-                    tol_abs = max(x1,x2)*self.tol
-                    if abs(x2-x1) <= tol_abs:
-                        flag[i1]=True; flag[i2]=True
-                    k+=1
+                    t2, x2, i2 = BtoA[k]
+                    tol_abs = max(x1, x2) * self.tol
+                    if abs(x2 - x1) <= tol_abs:
+                        flag[i1] = True
+                        flag[i2] = True
+                    k += 1
         df["sig_yoyo"] = flag
         return df

--- a/coi_fraud/io/ingest.py
+++ b/coi_fraud/io/ingest.py
@@ -1,16 +1,154 @@
+import re
+from typing import Iterable, Optional, Sequence
 
 import pandas as pd
-from ..schemas import BASE_COLS
-from ..utils.time import ensure_time_column, add_month_id
 
-def ingest_df(df: pd.DataFrame) -> pd.DataFrame:
-    missing = set(BASE_COLS) - set(df.columns)
+from ..schemas import (
+    BASE_COLS,
+    COL_AMOUNT,
+    COL_DATETIME,
+    COL_DESCRIPTION,
+    COL_RECEIVER_AGE,
+    COL_RECEIVER_FULL_NAME,
+    COL_RECEIVER_JOB,
+    COL_RECEIVER_STATE,
+    COL_RECEIVER_TENURE_YEARS,
+    COL_RECEIVER_ID,
+    COL_RELATION,
+    COL_SENDER_AGE,
+    COL_SENDER_FULL_NAME,
+    COL_SENDER_JOB,
+    COL_SENDER_STATE,
+    COL_SENDER_TENURE_YEARS,
+    COL_SENDER_ID,
+)
+from ..utils.time import ensure_time_column, add_month_id
+from ..utils.tx_desc import split_transaction_desc
+
+LOAD_DATE_COL = "load_date"
+TX_DESC_COL = "transaction_desc"
+TEAMMATES_COL = "companeros_de_equipo"
+MANAGER_COLS = [f"manager_{i}_user_id" for i in range(1, 5)]
+SENDER_META_SOURCE = {
+    "envio-nombre_completo": COL_SENDER_FULL_NAME,
+    "envio-puesto": COL_SENDER_JOB,
+    "envio-edad": COL_SENDER_AGE,
+    "envio-state_id": COL_SENDER_STATE,
+}
+RECEIVER_META_SOURCE = {
+    "receptor-nombre_completo": COL_RECEIVER_FULL_NAME,
+    "receptor-puesto": COL_RECEIVER_JOB,
+    "receptor-edad": COL_RECEIVER_AGE,
+    "receptor-state_id": COL_RECEIVER_STATE,
+}
+SENDER_HIRE_DATE_COL = "envio-gf_worker_hiring_date"
+RECEIVER_HIRE_DATE_COL = "receptor-gf_worker_hiring_date"
+
+
+def _normalize_ampm(text: str) -> str:
+    text = text.strip()
+    # Unifica variaciones en español de AM/PM
+    text = re.sub(r"(?i)\b([ap])\.?\s*m\.?\b", lambda m: "AM" if m.group(1).lower() == "a" else "PM", text)
+    return text
+
+
+def _parse_load_datetime(series: pd.Series) -> pd.Series:
+    cleaned = series.astype("string").fillna("").map(lambda x: _normalize_ampm(x) if x else x)
+    dt = pd.to_datetime(cleaned, errors="coerce")
+    return dt.mask(cleaned == "")
+
+
+def _split_teammates(value: Optional[str]) -> Sequence[str]:
+    if pd.isna(value):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(v).strip() for v in value if pd.notna(v) and str(v).strip()]
+    text = str(value)
+    if not text:
+        return []
+    parts = re.split(r"[\s,;|_]+", text)
+    return [p for p in (part.strip() for part in parts) if p]
+
+
+def _infer_relacion(row: pd.Series) -> str:
+    sender = row.get(COL_SENDER_ID)
+    receiver = row.get(COL_RECEIVER_ID)
+    if pd.isna(receiver) or receiver == "":
+        return "sin_dato"
+    if receiver == sender:
+        return "mismo_usuario"
+    managers = {row.get(col) for col in MANAGER_COLS if col in row and pd.notna(row[col])}
+    if receiver in managers:
+        return "manager_del_emisor"
+    teammates = set(_split_teammates(row.get(TEAMMATES_COL)))
+    if receiver in teammates:
+        return "companero_equipo"
+    return "otro"
+
+
+def _compute_tenure_years(reference_dt: pd.Series, hire_series: Optional[pd.Series]) -> pd.Series:
+    if hire_series is None:
+        return pd.Series(pd.NA, index=reference_dt.index, dtype="float64")
+    ref = pd.to_datetime(reference_dt, errors="coerce")
+    hire = pd.to_datetime(hire_series, errors="coerce", dayfirst=True)
+    try:
+        tz = ref.dt.tz
+    except AttributeError:
+        tz = None
+    if tz is not None:
+        ref = ref.dt.tz_convert(None)
+    try:
+        tz_hire = hire.dt.tz
+    except AttributeError:
+        tz_hire = None
+    if tz_hire is not None:
+        hire = hire.dt.tz_convert(None)
+    tenure_days = (ref - hire).dt.days
+    tenure_years = tenure_days / 365.25
+    return tenure_years.round(2)
+
+
+def _ensure_columns(df: pd.DataFrame, cols: Iterable[str]) -> None:
+    missing = set(cols) - set(df.columns)
     if missing:
         raise ValueError(f"Faltan columnas base: {missing}")
+
+
+def ingest_df(df: pd.DataFrame) -> pd.DataFrame:
+    raw_required = {COL_SENDER_ID, COL_RECEIVER_ID, COL_AMOUNT, LOAD_DATE_COL, TX_DESC_COL}
+    _ensure_columns(df, raw_required)
     df = df.copy()
-    df["monto"] = pd.to_numeric(df["monto"], errors="coerce")
+
+    df[COL_AMOUNT] = pd.to_numeric(df[COL_AMOUNT], errors="coerce")
+    df[COL_DATETIME] = _parse_load_datetime(df[LOAD_DATE_COL])
+
+    df = split_transaction_desc(df, col=TX_DESC_COL, prefix="tx_", keep_original=True)
+    service = df["tx_service"].astype("string").fillna("").str.strip()
+    detail = df["tx_detail"].astype("string").fillna("").str.strip()
+    code = df["tx_code"].astype("string").fillna("").str.strip()
+    combined = service.str.cat(detail.where(detail != ""), sep=" ", na_rep="").str.replace(r"\s+", " ", regex=True).str.strip()
+    combined = combined.str.cat(code.where(code != ""), sep=" ", na_rep="").str.replace(r"\s+", " ", regex=True).str.strip()
+    fallback = df[TX_DESC_COL].astype("string").fillna("").str.strip()
+    desc = combined.where(combined != "", fallback)
+    df[COL_DESCRIPTION] = desc.replace({"": pd.NA})
+
+    df[COL_RELATION] = df.apply(_infer_relacion, axis=1)
+
+    for src, dst in SENDER_META_SOURCE.items():
+        df[dst] = df[src] if src in df.columns else pd.NA
+    for src, dst in RECEIVER_META_SOURCE.items():
+        df[dst] = df[src] if src in df.columns else pd.NA
+
+    df[COL_SENDER_TENURE_YEARS] = _compute_tenure_years(df[COL_DATETIME], df.get(SENDER_HIRE_DATE_COL))
+    df[COL_RECEIVER_TENURE_YEARS] = _compute_tenure_years(df[COL_DATETIME], df.get(RECEIVER_HIRE_DATE_COL))
+
+    df[COL_SENDER_AGE] = pd.to_numeric(df[COL_SENDER_AGE], errors="coerce")
+    df[COL_RECEIVER_AGE] = pd.to_numeric(df[COL_RECEIVER_AGE], errors="coerce")
+
+    _ensure_columns(df, BASE_COLS)
     df = ensure_time_column(df, "fecha_hora_ts")
-    df = df.dropna(subset=["monto","fecha_hora_ts"])
+    df = df.dropna(subset=[COL_AMOUNT, "fecha_hora_ts"])
     df = add_month_id(df, "fecha_hora_ts", "month_id")
     df = df.sort_values("fecha_hora_ts").reset_index(drop=True)
+
     return df

--- a/coi_fraud/schemas.py
+++ b/coi_fraud/schemas.py
@@ -1,10 +1,76 @@
+COL_SENDER_ID = "user_id"
+COL_RECEIVER_ID = "receptor-user_id"
+COL_RELATION = "relacion"
+COL_DATETIME = "fecha_hora"
+COL_AMOUNT = "movement_amount"
+COL_DESCRIPTION = "descripcion"
 
-BASE_COLS = ["persona_1","persona_2","relacion","fecha_hora","monto","descripcion"]
+COL_SENDER_FULL_NAME = "user_nombre_completo"
+COL_RECEIVER_FULL_NAME = "receptor_nombre_completo"
+COL_SENDER_JOB = "user_puesto"
+COL_RECEIVER_JOB = "receptor_puesto"
+COL_SENDER_TENURE_YEARS = "user_antiguedad_anios"
+COL_RECEIVER_TENURE_YEARS = "receptor_antiguedad_anios"
+COL_SENDER_AGE = "user_edad"
+COL_RECEIVER_AGE = "receptor_edad"
+COL_SENDER_STATE = "user_estado"
+COL_RECEIVER_STATE = "receptor_estado"
+
+BASE_COLS = [
+    COL_SENDER_ID,
+    COL_RECEIVER_ID,
+    COL_RELATION,
+    COL_DATETIME,
+    COL_AMOUNT,
+    COL_DESCRIPTION,
+]
+
+PERSON_METADATA_COLS = [
+    COL_SENDER_FULL_NAME,
+    COL_SENDER_JOB,
+    COL_SENDER_TENURE_YEARS,
+    COL_SENDER_AGE,
+    COL_SENDER_STATE,
+    COL_RECEIVER_FULL_NAME,
+    COL_RECEIVER_JOB,
+    COL_RECEIVER_TENURE_YEARS,
+    COL_RECEIVER_AGE,
+    COL_RECEIVER_STATE,
+]
 
 TX_COLS_EXPORT = [
-    "fecha_hora_ts","month_id","persona_1","persona_2","relacion","monto","descripcion",
-    "risk_score","risk_score_norm","risk_tier","interp_tx",
-    "sig_yoyo","sig_smurf","sig_loan_bad_repay","sig_freq","sig_recurrent",
-    "sig_roundsum","sig_near_thr","sig_sna_cycle","sig_sna_triangle",
-    "nlp_concepto_sospechoso","feat_nlp_risk_points","feat_nlp_vaguedad","feat_nlp_emocion"
+    "fecha_hora_ts",
+    "month_id",
+    COL_SENDER_ID,
+    COL_RECEIVER_ID,
+    COL_RELATION,
+    COL_AMOUNT,
+    COL_DESCRIPTION,
+    COL_SENDER_FULL_NAME,
+    COL_SENDER_JOB,
+    COL_SENDER_TENURE_YEARS,
+    COL_SENDER_AGE,
+    COL_SENDER_STATE,
+    COL_RECEIVER_FULL_NAME,
+    COL_RECEIVER_JOB,
+    COL_RECEIVER_TENURE_YEARS,
+    COL_RECEIVER_AGE,
+    COL_RECEIVER_STATE,
+    "risk_score",
+    "risk_score_norm",
+    "risk_tier",
+    "interp_tx",
+    "sig_yoyo",
+    "sig_smurf",
+    "sig_loan_bad_repay",
+    "sig_freq",
+    "sig_recurrent",
+    "sig_roundsum",
+    "sig_near_thr",
+    "sig_sna_cycle",
+    "sig_sna_triangle",
+    "nlp_concepto_sospechoso",
+    "feat_nlp_risk_points",
+    "feat_nlp_vaguedad",
+    "feat_nlp_emocion",
 ]

--- a/coi_fraud/utils/sna.py
+++ b/coi_fraud/utils/sna.py
@@ -1,29 +1,38 @@
-
 from collections import defaultdict
+
 import pandas as pd
 
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
 def sna_light(df: pd.DataFrame):
-    out_sum = df.groupby("persona_1", observed=True)["monto"].sum().to_dict()
-    in_sum = df.groupby("persona_2", observed=True)["monto"].sum().to_dict()
-    df["p1_out_sum"] = df["persona_1"].map(out_sum).fillna(0.0).astype(float)
-    df["p2_in_sum"]  = df["persona_2"].map(in_sum).fillna(0.0).astype(float)
+    out_sum = df.groupby(COL_SENDER_ID, observed=True)[COL_AMOUNT].sum().to_dict()
+    in_sum = df.groupby(COL_RECEIVER_ID, observed=True)[COL_AMOUNT].sum().to_dict()
+    df["p1_out_sum"] = df[COL_SENDER_ID].map(out_sum).fillna(0.0).astype(float)
+    df["p2_in_sum"] = df[COL_RECEIVER_ID].map(in_sum).fillna(0.0).astype(float)
 
     adj_out = defaultdict(set)
     und = defaultdict(set)
-    for a,b in zip(df["persona_1"], df["persona_2"]):
-        adj_out[a].add(b); und[a].add(b); und[b].add(a)
-    nodes = set(df["persona_1"]).union(set(df["persona_2"]))
+    for a, b in zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID]):
+        adj_out[a].add(b)
+        und[a].add(b)
+        und[b].add(a)
+    nodes = set(df[COL_SENDER_ID]).union(set(df[COL_RECEIVER_ID]))
     in_triangle = {n: False for n in nodes}
     in_cycle = {n: False for n in nodes}
 
     for n in nodes:
         nbrs = list(und.get(n, []))
         for i in range(len(nbrs)):
-            u = nbrs[i]; Nu = und.get(u, set())
-            for j in range(i+1, len(nbrs)):
+            u = nbrs[i]
+            Nu = und.get(u, set())
+            for j in range(i + 1, len(nbrs)):
                 v = nbrs[j]
-                if v in Nu: in_triangle[n] = True; break
-            if in_triangle[n]: break
+                if v in Nu:
+                    in_triangle[n] = True
+                    break
+            if in_triangle[n]:
+                break
 
     for a in nodes:
         for b in adj_out.get(a, []):
@@ -34,8 +43,8 @@ def sna_light(df: pd.DataFrame):
                     if d != a and b != d and a in adj_out.get(d, set()):
                         in_cycle[a] = in_cycle[b] = in_cycle[c] = in_cycle[d] = True
 
-    df["p1_in_triangle"] = df["persona_1"].map(in_triangle)
-    df["p2_in_triangle"] = df["persona_2"].map(in_triangle)
-    df["p1_in_cycle"]    = df["persona_1"].map(in_cycle)
-    df["p2_in_cycle"]    = df["persona_2"].map(in_cycle)
+    df["p1_in_triangle"] = df[COL_SENDER_ID].map(in_triangle)
+    df["p2_in_triangle"] = df[COL_RECEIVER_ID].map(in_triangle)
+    df["p1_in_cycle"] = df[COL_SENDER_ID].map(in_cycle)
+    df["p2_in_cycle"] = df[COL_RECEIVER_ID].map(in_cycle)
     return df

--- a/coi_fraud/utils/tx_desc.py
+++ b/coi_fraud/utils/tx_desc.py
@@ -1,0 +1,136 @@
+import re
+import pandas as pd
+
+__all__ = ["split_transaction_desc", "_split_transaction_desc_series"]
+
+
+def _split_transaction_desc_series(series: pd.Series) -> pd.DataFrame:
+    """
+    Divide descripciones heterogéneas de transacciones en partes estándar.
+
+    Entrada:
+        series: pandas.Series con textos de la columna 'transaction_desc'.
+
+    Salida (DataFrame):
+        - original: cadena original
+        - service: texto antes del primer identificador numérico (p.ej., 'BNET', 'PREST.', 'CARGO METAS', 'Trp redondeo de tarjeta')
+        - count: entero inicial si el texto empieza con un número (p.ej., '8 Trp ...')
+        - id1: primer token con dígitos (o dígitos mezclados con X), p.ej. '299XXX4746'
+        - id2: segundo token con dígitos, si existe (p.ej., '202509XXX')
+        - detail: texto entre id1 e id2; si no hay id2, texto posterior a id1
+        - code: sufijo tipo código operativo al final (p.ej., 'K82','K83','N06','H09','KN06') incluso pegado
+    """
+    if not isinstance(series, pd.Series):
+        raise TypeError("_split_transaction_desc_series espera un pandas.Series")
+
+    code_re = re.compile(r'([A-Z]{1,2}\d{2})\s*$', re.ASCII)
+    nbsp_re = re.compile(r'\u00A0')
+    letters = r"A-Za-zÁÉÍÓÚÜÑáéíóúüñ\."
+    # Solo separa cuando hay una palabra de ≥3 letras (no precedida por dígito) seguida por dígito
+    # Evita romper tokens como 980XXX4481
+    pre_num_re = re.compile(rf'(?<!\d)([{letters}]{{3,}})(\d)')
+    collapse_ws = re.compile(r'\s+')
+    token_with_digit = re.compile(r'\b\S*\d\S*\b')
+
+    def parse_one(raw):
+        if pd.isna(raw):
+            return {
+                'original': raw,
+                'service': None,
+                'count': None,
+                'id1': None,
+                'id2': None,
+                'detail': None,
+                'code': None,
+            }
+
+        t = str(raw)
+        t = nbsp_re.sub(' ', t)
+        t = collapse_ws.sub(' ', t).strip()
+
+        # 1) Código al final (soporta pegado, p.ej., ...000H09)
+        code = None
+        m = code_re.search(t)
+        if m:
+            code = m.group(1)
+            t = t[:m.start()].rstrip()
+
+        # 2) Separar letras<->dígitos para palabras largas: 'METAS2323' -> 'METAS 2323', 'tarjeta11...' -> 'tarjeta 11...'
+        t = pre_num_re.sub(r'\1 \2', t)
+        t = collapse_ws.sub(' ', t).strip()
+
+        # 3) Contador inicial (p.ej., '8 Trp ...')
+        count = None
+        mcount = re.match(r'^(\d+)\b\s+', t)
+        if mcount:
+            try:
+                count = int(mcount.group(1))
+            except Exception:
+                count = None
+            t = t[mcount.end():].strip()
+
+        # 4) Identificadores con dígitos (conserva 'XXX' intercaladas)
+        digit_tokens = token_with_digit.findall(t)
+        id1 = digit_tokens[0] if digit_tokens else None
+        id2 = digit_tokens[1] if len(digit_tokens) > 1 else None
+
+        # 5) service / detail
+        if id1:
+            pos1 = t.find(id1)
+            pre = t[:pos1].strip()
+            post = t[pos1 + len(id1):].strip()
+            if id2:
+                pos2 = post.find(id2)
+                if pos2 >= 0:
+                    detail = post[:pos2].strip() or None
+                else:
+                    detail = post or None
+            else:
+                detail = post or None
+            service = pre or None
+        else:
+            service = t or None
+            detail = None
+
+        return {
+            'original': raw,
+            'service': service,
+            'count': count,
+            'id1': id1,
+            'id2': id2,
+            'detail': detail,
+            'code': code,
+        }
+
+    return series.apply(parse_one).apply(pd.Series)
+
+
+def split_transaction_desc(
+    df: pd.DataFrame,
+    col: str = "transaction_desc",
+    *,
+    prefix: str = "tx_",
+    keep_original: bool = True,
+) -> pd.DataFrame:
+    """
+    Añade las columnas parseadas al DataFrame a partir de 'col'.
+
+    Parámetros:
+        df: DataFrame de entrada
+        col: nombre de la columna con la descripción de la transacción
+        prefix: prefijo para las nuevas columnas (p.ej., 'tx_')
+        keep_original: si False, elimina la columna original
+
+    Retorna:
+        DataFrame con columnas agregadas:
+        f'{prefix}service', f'{prefix}count', f'{prefix}id1',
+        f'{prefix}id2', f'{prefix}detail', f'{prefix}code'
+    """
+    parts = _split_transaction_desc_series(df[col])
+    # Renombrar y seleccionar columnas útiles (omitimos 'original')
+    parts = parts[['service', 'count', 'id1', 'id2', 'detail', 'code']].add_prefix(prefix)
+    out = df.copy()
+    out = pd.concat([out, parts], axis=1)
+    if not keep_original:
+        out = out.drop(columns=[col])
+    return out

--- a/coi_fraud/viz/plots.py
+++ b/coi_fraud/viz/plots.py
@@ -1,72 +1,198 @@
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
 
-import pandas as pd, seaborn as sns, matplotlib.pyplot as plt
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_RELATION, COL_SENDER_ID
+
+
 def plot_constant_receipt_heatmap(reports, ax=None):
-    df = reports["agg_par_mensual"][["month_id","pair","tx_count"]].copy()
-    pivot = df.pivot_table(index="pair", columns="month_id", values="tx_count", fill_value=0, aggfunc="sum")
-    ax = ax or plt.figure().gca(); sns.heatmap(pivot, ax=ax)
-    ax.set_title("Constancia de recepción por par (tx_count por mes)"); ax.set_xlabel("month_id"); ax.set_ylabel("pair")
+    df = reports["agg_par_mensual"][
+        ["month_id", "pair", "tx_count"]
+    ].copy()
+    pivot = df.pivot_table(
+        index="pair",
+        columns="month_id",
+        values="tx_count",
+        fill_value=0,
+        aggfunc="sum",
+    )
+    ax = ax or plt.figure().gca()
+    sns.heatmap(pivot, ax=ax)
+    ax.set_title("Constancia de recepción por par (tx_count por mes)")
+    ax.set_xlabel("month_id")
+    ax.set_ylabel("pair")
     return ax
+
 
 def plot_person_imbalance_bar(reports, month_id=None, ax=None):
     df = reports["agg_persona_mensual"].copy()
-    if month_id is None and len(df): month_id = df["month_id"].iloc[0]
-    dd = df[df["month_id"]==month_id].copy(); dd["net"] = dd["sum_emit"] - dd["sum_recv"]
+    if month_id is None and len(df):
+        month_id = df["month_id"].iloc[0]
+    dd = df[df["month_id"] == month_id].copy()
+    dd["net"] = dd["sum_emit"] - dd["sum_recv"]
     dd = dd.sort_values("net", ascending=False).head(25)
-    ax = ax or plt.figure().gca(); sns.barplot(data=dd, x="net", y="persona", ax=ax)
-    ax.set_title(f"Desbalance emite-recibe (top 25) — {month_id}"); ax.set_xlabel("neto"); ax.set_ylabel("persona"); return ax
+    ax = ax or plt.figure().gca()
+    sns.barplot(data=dd, x="net", y="persona", ax=ax)
+    ax.set_title(f"Desbalance emite-recibe (top 25) — {month_id}")
+    ax.set_xlabel("neto")
+    ax.set_ylabel("persona")
+    return ax
+
 
 def plot_manager_concepts_bar(reports, month_id=None, ax=None):
     tx = reports["tx_transacciones_priorizadas"].copy()
-    mgr = tx[tx["relacion"].str.contains("Manager", case=False, na=False)]
-    if month_id is not None: mgr = mgr[mgr["month_id"]==month_id]
-    agg = (mgr.groupby("nlp_concepto_sospechoso")["monto"].count().sort_values(ascending=False).reset_index(name="tx_count"))
-    ax = ax or plt.figure().gca(); sns.barplot(data=agg, y="nlp_concepto_sospechoso", x="tx_count", ax=ax)
-    ax.set_title("Relaciones Manager — conceptos NLP"); ax.set_xlabel("tx_count"); ax.set_ylabel("concepto"); return ax
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
+    if month_id is not None:
+        mgr = mgr[mgr["month_id"] == month_id]
+    agg = (
+        mgr.groupby("nlp_concepto_sospechoso")[COL_AMOUNT]
+        .count()
+        .sort_values(ascending=False)
+        .reset_index(name="tx_count")
+    )
+    ax = ax or plt.figure().gca()
+    sns.barplot(data=agg, y="nlp_concepto_sospechoso", x="tx_count", ax=ax)
+    ax.set_title("Relaciones Manager — conceptos NLP")
+    ax.set_xlabel("tx_count")
+    ax.set_ylabel("concepto")
+    return ax
+
 
 def plot_centralizer_scatter(reports, month_id=None, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","monto","risk_score"]].copy()
-    dd = (tx.groupby(["month_id","persona_2"], as_index=False)
-        .agg(inflow=("monto","sum"), emisores_unicos=("persona_1","nunique"), n_tx=("monto","count"), risk_avg=("risk_score","mean")))
-    if month_id is None and len(dd): month_id = dd["month_id"].iloc[0]
-    dd = dd[dd["month_id"]==month_id]
-    ax = ax or plt.figure().gca(); sns.scatterplot(data=dd, x="emisores_unicos", y="inflow", size="n_tx", hue="risk_avg", ax=ax)
-    ax.set_title(f"Centralización de inflow — {month_id}"); ax.set_xlabel("emisores_unicos"); ax.set_ylabel("inflow"); return ax
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, COL_AMOUNT, "risk_score"]
+    ].copy()
+    dd = (
+        tx.groupby(["month_id", COL_RECEIVER_ID], as_index=False)
+        .agg(
+            inflow=(COL_AMOUNT, "sum"),
+            emisores_unicos=(COL_SENDER_ID, "nunique"),
+            n_tx=(COL_AMOUNT, "count"),
+            risk_avg=("risk_score", "mean"),
+        )
+    )
+    if month_id is None and len(dd):
+        month_id = dd["month_id"].iloc[0]
+    dd = dd[dd["month_id"] == month_id]
+    ax = ax or plt.figure().gca()
+    sns.scatterplot(
+        data=dd,
+        x="emisores_unicos",
+        y="inflow",
+        size="n_tx",
+        hue="risk_avg",
+        ax=ax,
+    )
+    ax.set_title(f"Centralización de inflow — {month_id}")
+    ax.set_xlabel("emisores_unicos")
+    ax.set_ylabel("inflow")
+    return ax
+
 
 def plot_yoyo_pairs_timeline(reports, ax=None):
-    par = reports["agg_par_mensual"][["month_id","pair","pct_yoyo"]].copy()
-    top_pairs = (par.groupby("pair")["pct_yoyo"].mean().sort_values(ascending=False).head(10).index.tolist())
+    par = reports["agg_par_mensual"][
+        ["month_id", "pair", "pct_yoyo"]
+    ].copy()
+    top_pairs = (
+        par.groupby("pair")["pct_yoyo"].mean().sort_values(ascending=False).head(10).index.tolist()
+    )
     dd = par[par["pair"].isin(top_pairs)]
-    ax = ax or plt.figure().gca(); sns.lineplot(data=dd, x="month_id", y="pct_yoyo", hue="pair", marker="o", ax=ax)
-    ax.set_title("Yo-Yo por mes (top 10 pares)"); ax.set_xlabel("month_id"); ax.set_ylabel("pct_yoyo"); return ax
+    ax = ax or plt.figure().gca()
+    sns.lineplot(data=dd, x="month_id", y="pct_yoyo", hue="pair", marker="o", ax=ax)
+    ax.set_title("Yo-Yo por mes (top 10 pares)")
+    ax.set_xlabel("month_id")
+    ax.set_ylabel("pct_yoyo")
+    return ax
+
 
 def plot_near_threshold_heatmap(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","sig_near_thr"]].copy()
-    tx["pair"] = tx["persona_1"] + "→" + tx["persona_2"]
-    near = tx.groupby(["pair","month_id"], as_index=False)["sig_near_thr"].mean()
-    pivot = near.pivot_table(index="pair", columns="month_id", values="sig_near_thr", fill_value=0, aggfunc="mean")
-    ax = ax or plt.figure().gca(); sns.heatmap(pivot, ax=ax)
-    ax.set_title("Cerca de umbral — intensidad por par/mes"); ax.set_xlabel("month_id"); ax.set_ylabel("pair"); return ax
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]
+    ].copy()
+    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+    near = tx.groupby(["pair", "month_id"], as_index=False)["sig_near_thr"].mean()
+    pivot = near.pivot_table(
+        index="pair",
+        columns="month_id",
+        values="sig_near_thr",
+        fill_value=0,
+        aggfunc="mean",
+    )
+    ax = ax or plt.figure().gca()
+    sns.heatmap(pivot, ax=ax)
+    ax.set_title("Cerca de umbral — intensidad por par/mes")
+    ax.set_xlabel("month_id")
+    ax.set_ylabel("pair")
+    return ax
+
 
 def plot_manager_concepts_risk(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","relacion","nlp_concepto_sospechoso","risk_score"]].copy()
-    mgr = tx[tx["relacion"].str.contains("Manager", case=False, na=False)]
-    agg = (mgr.groupby(["month_id","nlp_concepto_sospechoso"], as_index=False)
-           .agg(tx_count=("risk_score","count"), risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0)))
-    ax = ax or plt.figure().gca(); sns.scatterplot(data=agg, x="risk_p95", y="tx_count", hue="nlp_concepto_sospechoso", style="month_id", ax=ax)
-    ax.set_title("Manager: conceptos vs severidad (p95)"); ax.set_xlabel("risk_p95"); ax.set_ylabel("tx_count"); return ax
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_RELATION, "nlp_concepto_sospechoso", "risk_score"]
+    ].copy()
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
+    agg = (
+        mgr.groupby(["month_id", "nlp_concepto_sospechoso"], as_index=False)
+        .agg(
+            tx_count=("risk_score", "count"),
+            risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0),
+        )
+    )
+    ax = ax or plt.figure().gca()
+    sns.scatterplot(
+        data=agg,
+        x="risk_p95",
+        y="tx_count",
+        hue="nlp_concepto_sospechoso",
+        style="month_id",
+        ax=ax,
+    )
+    ax.set_title("Manager: conceptos vs severidad (p95)")
+    ax.set_xlabel("risk_p95")
+    ax.set_ylabel("tx_count")
+    return ax
+
 
 def plot_loan_freq_dual(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][["month_id","persona_1","persona_2","sig_loan_bad_repay","sig_freq"]].copy()
-    tx["pair"] = tx["persona_1"] + "→" + tx["persona_2"]
-    mes_flag = (tx.groupby(["pair","month_id"], as_index=False)
-                  .agg(loan_bad=("sig_loan_bad_repay","max"), freq=("sig_freq","mean"))
-                  .assign(hit=lambda d: d["loan_bad"] & (d["freq"]>0)))
-    agg = mes_flag.groupby("pair", as_index=False)["hit"].sum().rename(columns={"hit":"meses_condicion"}).sort_values("meses_condicion", ascending=False).head(25)
-    ax = ax or plt.figure().gca(); sns.barplot(data=agg, x="meses_condicion", y="pair", ax=ax)
-    ax.set_title("Préstamo sin repago + alta frecuencia"); ax.set_xlabel("meses_condicion"); ax.set_ylabel("pair"); return ax
+    tx = reports["tx_transacciones_priorizadas"][
+        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]
+    ].copy()
+    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+    mes_flag = (
+        tx.groupby(["pair", "month_id"], as_index=False)
+        .agg(loan_bad=("sig_loan_bad_repay", "max"), freq=("sig_freq", "mean"))
+        .assign(hit=lambda d: d["loan_bad"] & (d["freq"] > 0))
+    )
+    agg = (
+        mes_flag.groupby("pair", as_index=False)["hit"]
+        .sum()
+        .rename(columns={"hit": "meses_condicion"})
+        .sort_values("meses_condicion", ascending=False)
+        .head(25)
+    )
+    ax = ax or plt.figure().gca()
+    sns.barplot(data=agg, x="meses_condicion", y="pair", ax=ax)
+    ax.set_title("Préstamo sin repago + alta frecuencia")
+    ax.set_xlabel("meses_condicion")
+    ax.set_ylabel("pair")
+    return ax
+
 
 def plot_smurf_chronic(reports, ax=None):
-    par = reports["agg_par_mensual"][["pair","month_id","pct_smurf"]].copy()
-    agg = (par.assign(hit=par["pct_smurf"]>0).groupby("pair", as_index=False)["hit"].sum().rename(columns={"hit":"meses_smurf"}).sort_values("meses_smurf", ascending=False).head(25))
-    ax = ax or plt.figure().gca(); sns.barplot(data=agg, x="meses_smurf", y="pair", ax=ax)
-    ax.set_title("Smurfing crónico (meses con señal)"); ax.set_xlabel("meses_smurf"); ax.set_ylabel("pair"); return ax
+    par = reports["agg_par_mensual"][
+        ["pair", "month_id", "pct_smurf"]
+    ].copy()
+    agg = (
+        par.assign(hit=par["pct_smurf"] > 0)
+        .groupby("pair", as_index=False)["hit"]
+        .sum()
+        .rename(columns={"hit": "meses_smurf"})
+        .sort_values("meses_smurf", ascending=False)
+        .head(25)
+    )
+    ax = ax or plt.figure().gca()
+    sns.barplot(data=agg, x="meses_smurf", y="pair", ax=ax)
+    ax.set_title("Smurfing crónico (meses con señal)")
+    ax.set_xlabel("meses_smurf")
+    ax.set_ylabel("pair")
+    return ax


### PR DESCRIPTION
## Summary
- add reusable column name constants for the new transaction schema and extend exports to surface sender/receiver metadata
- overhaul ingestion to derive relationships, timestamps, descriptions, and tenure fields from the new raw columns using the shared transaction description parser
- update feature, analytics, and visualization modules to rely on the shared schema constants and the movement_amount field instead of legacy names

## Testing
- python -m compileall coi_fraud

------
https://chatgpt.com/codex/tasks/task_e_68dd8766bb24832cb47de074a7f416ac