### PR TITLE
Add timeframe-aware reports with cluster analytics

### DIFF
--- a/coi_fraud/aggregate/clusters.py
+++ b/coi_fraud/aggregate/clusters.py
@@ -1,0 +1,180 @@
+from collections import defaultdict, deque
+from typing import Dict, Iterable, List, Set
+
+import pandas as pd
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
+def _build_components(edges: Iterable[tuple]) -> List[Set]:
+    adjacency: Dict = defaultdict(set)
+    nodes: Set = set()
+    for sender, receiver in edges:
+        if pd.isna(sender) or pd.isna(receiver):
+            continue
+        adjacency[sender].add(receiver)
+        adjacency[receiver].add(sender)
+        nodes.add(sender)
+        nodes.add(receiver)
+    visited: Set = set()
+    components: List[Set] = []
+    for node in nodes:
+        if node in visited:
+            continue
+        queue = deque([node])
+        comp: Set = set()
+        while queue:
+            current = queue.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+            comp.add(current)
+            for neighbour in adjacency.get(current, set()):
+                if neighbour not in visited:
+                    queue.append(neighbour)
+        if comp:
+            components.append(comp)
+    return components
+
+
+def _top_concepts(df: pd.DataFrame) -> List[str]:
+    if df.empty:
+        return []
+    counts = (
+        df.groupby("nlp_concepto_sospechoso", observed=True)[COL_AMOUNT]
+        .count()
+        .reset_index(name="cnt")
+        .sort_values(["cnt", "nlp_concepto_sospechoso"], ascending=[False, True])
+    )
+    return counts["nlp_concepto_sospechoso"].head(3).tolist()
+
+
+def build_person_clusters(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "cluster_id",
+                "cluster_personas",
+                "cluster_personas_total",
+                "cluster_tx_count",
+                "cluster_tx_sum",
+                "riesgo_cluster_maximo",
+                "riesgo_cluster_promedio",
+                "nlp_cluster_total_transacciones_sospechosas",
+                "nlp_cluster_conceptos_sospechosos_unicos",
+                "nlp_cluster_top_conceptos",
+                "yo_yo_cluster_tasa_flag",
+                "smurf_cluster_tasa_flag",
+                "frecuencia_cluster_tasa_flag",
+                "recurrente_cluster_tasa_flag",
+                "prestamo_cluster_tasa_repay_insuficiente",
+                "monto_cluster_tasa_flag_redondo",
+                "umbral_cluster_tasa_flag_cercania",
+                "red_cluster_tasa_en_ciclos",
+                "red_cluster_tasa_en_triangulos",
+                "desbalance_cluster_persona_principal",
+                "desbalance_cluster_persona_principal_monto",
+                "interp_cluster",
+            ]
+        )
+
+    components = _build_components(zip(df[COL_SENDER_ID], df[COL_RECEIVER_ID]))
+    records: List[Dict] = []
+    concept_series = df.get("nlp_concepto_sospechoso", pd.Series([], dtype="string"))
+    concept_series = concept_series.fillna("").astype("string").str.strip()
+
+    for idx, comp in enumerate(components, start=1):
+        cluster_df = df[df[COL_SENDER_ID].isin(comp) & df[COL_RECEIVER_ID].isin(comp)].copy()
+        if cluster_df.empty:
+            continue
+        cluster_concepts = concept_series.loc[cluster_df.index]
+        suspicious_df = cluster_df.loc[cluster_concepts != ""]
+        emit = cluster_df.groupby(COL_SENDER_ID, observed=True)[COL_AMOUNT].sum()
+        recv = cluster_df.groupby(COL_RECEIVER_ID, observed=True)[COL_AMOUNT].sum()
+        balance = emit.sub(recv, fill_value=0.0)
+        if not balance.empty:
+            principal = balance.reindex(balance.abs().sort_values(ascending=False).index)
+            desbalance_persona = principal.index[0]
+            desbalance_monto = float(principal.iloc[0])
+        else:
+            desbalance_persona = None
+            desbalance_monto = 0.0
+
+        riesgo_max = cluster_df["risk_score"].max()
+        riesgo_avg = cluster_df["risk_score"].mean()
+        riesgo_max = float(riesgo_max) if pd.notna(riesgo_max) else 0.0
+        riesgo_avg = float(riesgo_avg) if pd.notna(riesgo_avg) else 0.0
+        record = {
+            "cluster_id": f"cluster_{idx}",
+            "cluster_personas": sorted(comp),
+            "cluster_personas_total": len(comp),
+            "cluster_tx_count": int(cluster_df.shape[0]),
+            "cluster_tx_sum": float(cluster_df[COL_AMOUNT].sum()),
+            "riesgo_cluster_maximo": riesgo_max,
+            "riesgo_cluster_promedio": riesgo_avg,
+            "nlp_cluster_total_transacciones_sospechosas": int(suspicious_df.shape[0]),
+            "nlp_cluster_conceptos_sospechosos_unicos": int(
+                suspicious_df["nlp_concepto_sospechoso"].nunique()
+            ),
+            "nlp_cluster_top_conceptos": _top_concepts(suspicious_df),
+            "yo_yo_cluster_tasa_flag": float(cluster_df["sig_yoyo"].fillna(0.0).mean()),
+            "smurf_cluster_tasa_flag": float(cluster_df["sig_smurf"].fillna(0.0).mean()),
+            "frecuencia_cluster_tasa_flag": float(cluster_df["sig_freq"].fillna(0.0).mean()),
+            "recurrente_cluster_tasa_flag": float(
+                cluster_df["sig_recurrent"].fillna(0.0).mean()
+            ),
+            "prestamo_cluster_tasa_repay_insuficiente": float(
+                cluster_df["sig_loan_bad_repay"].fillna(0.0).mean()
+            ),
+            "monto_cluster_tasa_flag_redondo": float(
+                cluster_df["sig_roundsum"].fillna(0.0).mean()
+            ),
+            "umbral_cluster_tasa_flag_cercania": float(
+                cluster_df["sig_near_thr"].fillna(0.0).mean()
+            ),
+            "red_cluster_tasa_en_ciclos": float(
+                cluster_df["p1_in_cycle"].fillna(0.0).mean()
+            ),
+            "red_cluster_tasa_en_triangulos": float(
+                cluster_df["p1_in_triangle"].fillna(0.0).mean()
+            ),
+            "desbalance_cluster_persona_principal": desbalance_persona,
+            "desbalance_cluster_persona_principal_monto": desbalance_monto,
+        }
+        record["interp_cluster"] = (
+            f"{record['cluster_personas_total']} personas con {record['cluster_tx_count']} tx "
+            f"(${record['cluster_tx_sum']:,.0f}). Riesgo max {record['riesgo_cluster_maximo']:.2f}."
+        )
+        records.append(record)
+
+    if not records:
+        return pd.DataFrame(
+            columns=[
+                "cluster_id",
+                "cluster_personas",
+                "cluster_personas_total",
+                "cluster_tx_count",
+                "cluster_tx_sum",
+                "riesgo_cluster_maximo",
+                "riesgo_cluster_promedio",
+                "nlp_cluster_total_transacciones_sospechosas",
+                "nlp_cluster_conceptos_sospechosos_unicos",
+                "nlp_cluster_top_conceptos",
+                "yo_yo_cluster_tasa_flag",
+                "smurf_cluster_tasa_flag",
+                "frecuencia_cluster_tasa_flag",
+                "recurrente_cluster_tasa_flag",
+                "prestamo_cluster_tasa_repay_insuficiente",
+                "monto_cluster_tasa_flag_redondo",
+                "umbral_cluster_tasa_flag_cercania",
+                "red_cluster_tasa_en_ciclos",
+                "red_cluster_tasa_en_triangulos",
+                "desbalance_cluster_persona_principal",
+                "desbalance_cluster_persona_principal_monto",
+                "interp_cluster",
+            ]
+        )
+
+    return pd.DataFrame(records).sort_values(
+        ["riesgo_cluster_maximo", "cluster_tx_sum"], ascending=[False, False]
+    )

--- a/coi_fraud/aggregate/concepts.py
+++ b/coi_fraud/aggregate/concepts.py
@@ -3,35 +3,94 @@ import pandas as pd
 from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
 
 
+def _suspicious_concepts(df: pd.DataFrame) -> pd.DataFrame:
+    conceptos = df.get("nlp_concepto_sospechoso")
+    if conceptos is None:
+        return df.iloc[0:0].copy()
+    conceptos = conceptos.fillna("").astype("string").str.strip()
+    mask = conceptos != ""
+    if not mask.any():
+        return df.iloc[0:0].copy()
+    out = df.loc[mask].copy()
+    out["nlp_concepto_sospechoso"] = (
+        out["nlp_concepto_sospechoso"].astype("string").str.strip()
+    )
+    return out
+
+
 def build_concept_tables(df: pd.DataFrame):
-    tx = df.copy()
-    txc = tx[tx["nlp_concepto_sospechoso"] != ""].copy()
+    txc = _suspicious_concepts(df)
+    if txc.empty:
+        conceptos = pd.DataFrame(
+            columns=[
+                "nlp_concepto_sospechoso",
+                "nlp_concepto_tx_total",
+                "nlp_concepto_monto_total",
+                "nlp_concepto_emisores_unicos",
+                "nlp_concepto_receptores_unicos",
+                "nlp_concepto_riesgo_promedio",
+                "nlp_concepto_riesgo_p95",
+            ]
+        )
+        persona = pd.DataFrame(
+            columns=[
+                "persona",
+                "nlp_concepto_sospechoso",
+                "nlp_persona_concepto_tx_total",
+                "nlp_persona_concepto_monto_total",
+                "nlp_persona_concepto_riesgo_promedio",
+            ]
+        )
+        par = pd.DataFrame(
+            columns=[
+                "pair",
+                "nlp_concepto_sospechoso",
+                "nlp_par_concepto_tx_total",
+                "nlp_par_concepto_monto_total",
+                "nlp_par_concepto_riesgo_promedio",
+            ]
+        )
+        return conceptos, persona, par
+
     agg_concepto = (
-        txc.groupby(["month_id", "nlp_concepto_sospechoso"], observed=True)
+        txc.groupby("nlp_concepto_sospechoso", observed=True)
         .agg(
-            tx_count=(COL_AMOUNT, "count"),
-            tx_sum=(COL_AMOUNT, "sum"),
-            emisores_unicos=(COL_SENDER_ID, "nunique"),
-            receptores_unicos=(COL_RECEIVER_ID, "nunique"),
-            risk_avg=("risk_score", "mean"),
-            risk_p95=(
+            nlp_concepto_tx_total=(COL_AMOUNT, "count"),
+            nlp_concepto_monto_total=(COL_AMOUNT, "sum"),
+            nlp_concepto_emisores_unicos=(COL_SENDER_ID, "nunique"),
+            nlp_concepto_receptores_unicos=(COL_RECEIVER_ID, "nunique"),
+            nlp_concepto_riesgo_promedio=("risk_score", "mean"),
+            nlp_concepto_riesgo_p95=(
                 "risk_score",
                 lambda s: float(s.quantile(0.95)) if len(s) else 0.0,
             ),
         )
         .reset_index()
-        .sort_values(["month_id", "risk_p95", "tx_count"], ascending=[True, False, False])
+        .sort_values(
+            ["nlp_concepto_riesgo_p95", "nlp_concepto_tx_total"],
+            ascending=[False, False],
+        )
     )
+
     agg_persona_concepto = (
-        txc.groupby(["month_id", COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)
-        .agg(tx_count=(COL_AMOUNT, "count"), tx_sum=(COL_AMOUNT, "sum"), risk_avg=("risk_score", "mean"))
+        txc.groupby([COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)
+        .agg(
+            nlp_persona_concepto_tx_total=(COL_AMOUNT, "count"),
+            nlp_persona_concepto_monto_total=(COL_AMOUNT, "sum"),
+            nlp_persona_concepto_riesgo_promedio=("risk_score", "mean"),
+        )
         .reset_index()
         .rename(columns={COL_SENDER_ID: "persona"})
     )
+
     txc["pair"] = txc[COL_SENDER_ID].astype(str) + "→" + txc[COL_RECEIVER_ID].astype(str)
     agg_par_concepto = (
-        txc.groupby(["month_id", "pair", "nlp_concepto_sospechoso"], observed=True)
-        .agg(tx_count=(COL_AMOUNT, "count"), tx_sum=(COL_AMOUNT, "sum"), risk_avg=("risk_score", "mean"))
+        txc.groupby(["pair", "nlp_concepto_sospechoso"], observed=True)
+        .agg(
+            nlp_par_concepto_tx_total=(COL_AMOUNT, "count"),
+            nlp_par_concepto_monto_total=(COL_AMOUNT, "sum"),
+            nlp_par_concepto_riesgo_promedio=("risk_score", "mean"),
+        )
         .reset_index()
     )
     return agg_concepto, agg_persona_concepto, agg_par_concepto

--- a/coi_fraud/aggregate/pairs.py
+++ b/coi_fraud/aggregate/pairs.py
@@ -1,14 +1,33 @@
 import pandas as pd
 
 from ..interpret.pair import pair_interpretation
-from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+from ..schemas import COL_AMOUNT, COL_SENDER_ID
 
 
 def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "pair",
+                "tx_count",
+                "tx_sum",
+                "risk_max",
+                "risk_avg",
+                "pct_yoyo",
+                "pct_smurf",
+                "pct_freq",
+                "pct_recurrent",
+                "interp_pair",
+                "nlp_par_total_transacciones_sospechosas",
+                "nlp_par_conceptos_sospechosos_unicos",
+                "nlp_par_top_conceptos",
+            ]
+        )
+
     tmp = df.copy()
     tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
     agg = (
-        tmp.groupby(["month_id", "pair"], observed=True)
+        tmp.groupby("pair", observed=True)
         .agg(
             tx_count=(COL_AMOUNT, "count"),
             tx_sum=(COL_AMOUNT, "sum"),
@@ -21,23 +40,54 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
         )
         .reset_index()
     )
-    topc = (
-        tmp[tmp["nlp_concepto_sospechoso"] != ""]
-        .groupby(["month_id", "pair", "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
-        .count()
-        .reset_index(name="cnt")
-    )
-    if len(topc):
+
+    suspicious_mask = tmp.get("nlp_concepto_sospechoso").fillna("").astype("string").str.strip() != ""
+    tmp_suspicious = tmp.loc[suspicious_mask].copy()
+    if not tmp_suspicious.empty:
+        concept_counts = (
+            tmp_suspicious.groupby("pair", observed=True)["nlp_concepto_sospechoso"]
+            .agg(
+                nlp_par_total_transacciones_sospechosas="count",
+                nlp_par_conceptos_sospechosos_unicos="nunique",
+            )
+            .reset_index()
+        )
         topc = (
-            topc.sort_values(["month_id", "pair", "cnt"], ascending=[True, True, False])
-            .groupby(["month_id", "pair"])
+            tmp_suspicious.groupby(["pair", "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
+            .count()
+            .reset_index(name="cnt")
+        )
+        topc = (
+            topc.sort_values(["pair", "cnt"], ascending=[True, False])
+            .groupby("pair")
             .head(3)
         )
         tops = (
-            topc.groupby(["month_id", "pair"])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
+            topc.groupby("pair")["nlp_concepto_sospechoso"].apply(list).rename("nlp_par_top_conceptos")
         )
-        agg = agg.merge(tops, on=["month_id", "pair"], how="left")
+        agg = agg.merge(concept_counts, on="pair", how="left")
+        agg = agg.merge(tops, on="pair", how="left")
     else:
-        agg["top_conceptos"] = [[] for _ in range(len(agg))]
+        agg["nlp_par_total_transacciones_sospechosas"] = 0
+        agg["nlp_par_conceptos_sospechosos_unicos"] = 0
+        agg["nlp_par_top_conceptos"] = [[] for _ in range(len(agg))]
+
+    for col in [
+        "nlp_par_total_transacciones_sospechosas",
+        "nlp_par_conceptos_sospechosos_unicos",
+    ]:
+        if col not in agg:
+            agg[col] = 0
+        else:
+            agg[col] = agg[col].fillna(0)
+    if "nlp_par_top_conceptos" not in agg:
+        agg["nlp_par_top_conceptos"] = [[] for _ in range(len(agg))]
+    else:
+        agg["nlp_par_top_conceptos"] = agg["nlp_par_top_conceptos"].apply(
+            lambda x: x if isinstance(x, list) else []
+        )
+
     agg["interp_pair"] = agg.apply(pair_interpretation, axis=1)
-    return agg.sort_values(["risk_max", "tx_sum"], ascending=[False, False])
+    agg = agg.sort_values(["risk_max", "tx_sum"], ascending=[False, False])
+    agg["top_conceptos"] = agg["nlp_par_top_conceptos"]
+    return agg

--- a/coi_fraud/aggregate/persons.py
+++ b/coi_fraud/aggregate/persons.py
@@ -4,9 +4,47 @@ from ..interpret.person import person_interpretation
 from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
 
 
+def _ensure_string(series: pd.Series) -> pd.Series:
+    return series.fillna("").astype("string").str.strip()
+
+
 def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "persona",
+                "n_tx_emit",
+                "sum_emit",
+                "avg_emit",
+                "risk_avg_em",
+                "risk_max_emit",
+                "n_tx_recv",
+                "sum_recv",
+                "avg_recv",
+                "risk_avg_re",
+                "risk_max_recv",
+                "risk_avg_person",
+                "top_conceptos",
+                "interp_person",
+                "nlp_persona_total_transacciones_sospechosas",
+                "nlp_persona_conceptos_sospechosos_unicos",
+                "nlp_persona_top_conceptos",
+                "desbalance_persona_monto_neto",
+                "desbalance_persona_ratio_emision_vs_recepcion",
+                "yo_yo_persona_tasa_flag_emisor",
+                "smurf_persona_tasa_flag_emisor",
+                "frecuencia_persona_tasa_flag_emisor",
+                "recurrente_persona_tasa_flag_emisor",
+                "prestamo_persona_tasa_repay_insuficiente",
+                "monto_persona_tasa_flag_redondo",
+                "umbral_persona_tasa_flag_cercania",
+                "red_persona_tasa_en_ciclos",
+                "red_persona_tasa_en_triangulos",
+            ]
+        )
+
     em = (
-        df.groupby(["month_id", COL_SENDER_ID], observed=True)
+        df.groupby(COL_SENDER_ID, observed=True)
         .agg(
             n_tx_emit=(COL_AMOUNT, "count"),
             sum_emit=(COL_AMOUNT, "sum"),
@@ -18,7 +56,7 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
         .reset_index()
     )
     re = (
-        df.groupby(["month_id", COL_RECEIVER_ID], observed=True)
+        df.groupby(COL_RECEIVER_ID, observed=True)
         .agg(
             n_tx_recv=(COL_AMOUNT, "count"),
             sum_recv=(COL_AMOUNT, "sum"),
@@ -29,7 +67,7 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
         .rename_axis(index={COL_RECEIVER_ID: "persona"})
         .reset_index()
     )
-    people = pd.merge(em, re, on=["month_id", "persona"], how="outer").fillna(
+    people = pd.merge(em, re, on="persona", how="outer").fillna(
         {
             "n_tx_emit": 0,
             "sum_emit": 0.0,
@@ -44,26 +82,109 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
         }
     )
     people["risk_avg_person"] = (people["risk_avg_em"] + people["risk_avg_re"]) / 2.0
-    topc = (
-        df[df["nlp_concepto_sospechoso"] != ""]
-        .groupby(["month_id", COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
-        .count()
-        .reset_index(name="cnt")
+
+    concept_series = _ensure_string(df.get("nlp_concepto_sospechoso", ""))
+    df_concepts = df.loc[concept_series != ""].copy()
+    df_concepts["nlp_concepto_sospechoso"] = concept_series.loc[df_concepts.index]
+
+    if not df_concepts.empty:
+        suspicious_counts = (
+            df_concepts.groupby(COL_SENDER_ID, observed=True)["nlp_concepto_sospechoso"]
+            .agg(
+                nlp_persona_total_transacciones_sospechosas="count",
+                nlp_persona_conceptos_sospechosos_unicos="nunique",
+            )
+            .reset_index()
+            .rename(columns={COL_SENDER_ID: "persona"})
+        )
+        topc = (
+            df_concepts.groupby([COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)[
+                COL_AMOUNT
+            ]
+            .count()
+            .reset_index(name="cnt")
+        )
+        topc = (
+            topc.sort_values([COL_SENDER_ID, "cnt"], ascending=[True, False])
+            .groupby(COL_SENDER_ID)
+            .head(3)
+        )
+        tops = (
+            topc.groupby(COL_SENDER_ID)["nlp_concepto_sospechoso"]
+            .apply(list)
+            .rename("nlp_persona_top_conceptos")
+            .reset_index()
+            .rename(columns={COL_SENDER_ID: "persona"})
+        )
+        people = people.merge(suspicious_counts, on="persona", how="left")
+        people = people.merge(tops, on="persona", how="left")
+    else:
+        people["nlp_persona_total_transacciones_sospechosas"] = 0
+        people["nlp_persona_conceptos_sospechosos_unicos"] = 0
+        people["nlp_persona_top_conceptos"] = [[] for _ in range(len(people))]
+
+    for col in [
+        "nlp_persona_total_transacciones_sospechosas",
+        "nlp_persona_conceptos_sospechosos_unicos",
+    ]:
+        if col not in people:
+            people[col] = 0
+        else:
+            people[col] = people[col].fillna(0)
+    if "nlp_persona_top_conceptos" not in people:
+        people["nlp_persona_top_conceptos"] = [[] for _ in range(len(people))]
+    else:
+        people["nlp_persona_top_conceptos"] = people["nlp_persona_top_conceptos"].apply(
+            lambda x: x if isinstance(x, list) else ([] if pd.isna(x) else [x])
+        )
+
+    flag_stats = (
+        df.groupby(COL_SENDER_ID, observed=True)
+        .agg(
+            yo_yo_persona_tasa_flag_emisor=("sig_yoyo", "mean"),
+            smurf_persona_tasa_flag_emisor=("sig_smurf", "mean"),
+            frecuencia_persona_tasa_flag_emisor=("sig_freq", "mean"),
+            recurrente_persona_tasa_flag_emisor=("sig_recurrent", "mean"),
+            prestamo_persona_tasa_repay_insuficiente=("sig_loan_bad_repay", "mean"),
+            monto_persona_tasa_flag_redondo=("sig_roundsum", "mean"),
+            umbral_persona_tasa_flag_cercania=("sig_near_thr", "mean"),
+            red_persona_tasa_en_ciclos=("p1_in_cycle", "mean"),
+            red_persona_tasa_en_triangulos=("p1_in_triangle", "mean"),
+        )
+        .reset_index()
+        .rename(columns={COL_SENDER_ID: "persona"})
     )
-    topc = (
-        topc.sort_values(["month_id", COL_SENDER_ID, "cnt"], ascending=[True, True, False])
-        .groupby(["month_id", COL_SENDER_ID])
-        .head(3)
+    people = people.merge(flag_stats, on="persona", how="left")
+
+    fill_cols = [
+        "yo_yo_persona_tasa_flag_emisor",
+        "smurf_persona_tasa_flag_emisor",
+        "frecuencia_persona_tasa_flag_emisor",
+        "recurrente_persona_tasa_flag_emisor",
+        "prestamo_persona_tasa_repay_insuficiente",
+        "monto_persona_tasa_flag_redondo",
+        "umbral_persona_tasa_flag_cercania",
+        "red_persona_tasa_en_ciclos",
+        "red_persona_tasa_en_triangulos",
+    ]
+    for col in fill_cols:
+        if col not in people:
+            people[col] = 0.0
+        else:
+            people[col] = people[col].fillna(0.0)
+
+    people["desbalance_persona_monto_neto"] = people["sum_emit"] - people["sum_recv"]
+    total_mov = people["sum_emit"] + people["sum_recv"]
+    people["desbalance_persona_ratio_emision_vs_recepcion"] = (
+        people["sum_emit"].where(total_mov == 0, people["sum_emit"] / total_mov)
     )
-    tops = (
-        topc.groupby(["month_id", COL_SENDER_ID])["nlp_concepto_sospechoso"].apply(list).rename("top_conceptos")
-    )
-    people = people.merge(
-        tops,
-        left_on=["month_id", "persona"],
-        right_on=["month_id", COL_SENDER_ID],
-        how="left",
-    ).drop(columns=[COL_SENDER_ID], errors="ignore")
+
+    if "nlp_persona_top_conceptos" in people:
+        people["top_conceptos"] = people["nlp_persona_top_conceptos"]
+    else:
+        people["top_conceptos"] = [[] for _ in range(len(people))]
     people["top_conceptos"] = people["top_conceptos"].apply(lambda x: x if isinstance(x, list) else [])
     people["interp_person"] = people.apply(person_interpretation, axis=1)
-    return people.sort_values(["risk_avg_person", "sum_emit", "sum_recv"], ascending=[False, False, False])
+    return people.sort_values(
+        ["risk_avg_person", "sum_emit", "sum_recv"], ascending=[False, False, False]
+    )

--- a/coi_fraud/aggregate/reports.py
+++ b/coi_fraud/aggregate/reports.py
@@ -1,18 +1,68 @@
 
-from .transactions import build_tx_table
+from datetime import timedelta
+from typing import Optional
+
+import pandas as pd
+
+from .clusters import build_person_clusters
+from .concepts import build_concept_tables
 from .pairs import build_pair_monthly
 from .persons import build_person_monthly
-from .concepts import build_concept_tables
-def build_all_reports(df):
-    tx = build_tx_table(df)
-    pairs = build_pair_monthly(df)
-    persons = build_person_monthly(df)
-    agg_concepto, agg_persona_concepto, agg_par_concepto = build_concept_tables(df)
-    return {
-        "tx_transacciones_priorizadas": tx,
-        "agg_par_mensual": pairs,
-        "agg_persona_mensual": persons,
-        "agg_concepto_mensual": agg_concepto,
-        "agg_persona_concepto_mensual": agg_persona_concepto,
-        "agg_par_concepto_mensual": agg_par_concepto,
+from .transactions import build_tx_table
+
+
+TIME_WINDOWS = {
+    "ultimo_mes": timedelta(days=30),
+    "ultimos_3_meses": timedelta(days=90),
+    "todo_el_tiempo": None,
+}
+
+
+def _slice_timeframe(df: pd.DataFrame, window: Optional[timedelta]) -> pd.DataFrame:
+    if window is None:
+        return df.copy()
+    if "fecha_hora_ts" not in df:
+        return df.copy()
+    max_ts = df["fecha_hora_ts"].max()
+    if pd.isna(max_ts):
+        return df.iloc[0:0].copy()
+    cutoff = max_ts - window
+    return df[df["fecha_hora_ts"] >= cutoff].copy()
+
+
+def _tag_timeframe(table: pd.DataFrame, label: str) -> pd.DataFrame:
+    if not isinstance(table, pd.DataFrame):
+        return table
+    tagged = table.copy()
+    tagged.insert(0, "timeframe_periodo", label)
+    return tagged
+
+
+def build_all_reports(df: pd.DataFrame):
+    outputs = {
+        "transaccion": {},
+        "persona": {},
+        "par_personas": {},
+        "concepto_descripcion": {},
+        "persona_concepto": {},
+        "par_concepto": {},
+        "clusters_personas": {},
     }
+    for label, window in TIME_WINDOWS.items():
+        sliced = _slice_timeframe(df, window)
+        tx = _tag_timeframe(build_tx_table(sliced), label)
+        persons = _tag_timeframe(build_person_monthly(sliced), label)
+        pairs = _tag_timeframe(build_pair_monthly(sliced), label)
+        concepts, persona_concepto, par_concepto = build_concept_tables(sliced)
+        concepts = _tag_timeframe(concepts, label)
+        persona_concepto = _tag_timeframe(persona_concepto, label)
+        par_concepto = _tag_timeframe(par_concepto, label)
+        clusters = _tag_timeframe(build_person_clusters(sliced), label)
+        outputs["transaccion"][label] = tx
+        outputs["persona"][label] = persons
+        outputs["par_personas"][label] = pairs
+        outputs["concepto_descripcion"][label] = concepts
+        outputs["persona_concepto"][label] = persona_concepto
+        outputs["par_concepto"][label] = par_concepto
+        outputs["clusters_personas"][label] = clusters
+    return outputs

--- a/coi_fraud/aggregate/transactions.py
+++ b/coi_fraud/aggregate/transactions.py
@@ -5,7 +5,13 @@ from ..interpret.tx import tx_interpretation
 def build_tx_table(df: pd.DataFrame) -> pd.DataFrame:
     out = df.copy()
     out["interp_tx"] = out.apply(tx_interpretation, axis=1)
+    sospechoso = out.get("nlp_concepto_sospechoso", "")
+    out["nlp_tx_flag_concepto_sospechoso"] = (
+        sospechoso.fillna("").astype("string").str.strip() != ""
+    )
     cols = [c for c in TX_COLS_EXPORT if c in out.columns]
+    extra_cols = ["nlp_tx_flag_concepto_sospechoso"]
+    cols.extend([c for c in extra_cols if c in out.columns and c not in cols])
     out = out[cols].sort_values(["risk_tier","risk_score","month_id"], ascending=[True,False,True])
     cat = pd.Categorical(out["risk_tier"], categories=["CRITICO","ALTO","MEDIO","BAJO"], ordered=True)
     out = out.assign(risk_tier=cat).sort_values(["risk_tier","risk_score"], ascending=[True,False])

--- a/coi_fraud/analysis/qa.py
+++ b/coi_fraud/analysis/qa.py
@@ -11,12 +11,40 @@ from ..schemas import (
 )
 
 
-def empleados_recepcion_constante(reports, min_meses=3):
-    d = reports["agg_par_mensual"][
-        ["month_id", "pair", "tx_count", "pct_recurrent"]
-    ].copy()
+def _get_section(reports, section, timeframe="todo_el_tiempo"):
+    data = reports.get(section, {})
+    if isinstance(data, dict):
+        df = data.get(timeframe)
+    else:
+        df = data
+    if isinstance(df, pd.DataFrame):
+        out = df.copy()
+        if "timeframe_periodo" in out.columns:
+            out = out.drop(columns=["timeframe_periodo"])
+        return out
+    return pd.DataFrame()
+
+
+def _get_tx(reports, timeframe="todo_el_tiempo"):
+    return _get_section(reports, "transaccion", timeframe)
+
+
+def empleados_recepcion_constante(reports, min_meses=3, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty or "month_id" not in tx:
+        return pd.DataFrame(columns=["pair", "meses_con_tx", "meses_recurrente"])
+    pairs = tx.copy()
+    pairs["pair"] = pairs[COL_SENDER_ID].astype(str) + "→" + pairs[COL_RECEIVER_ID].astype(str)
+    monthly = (
+        pairs.groupby(["month_id", "pair"], observed=True)
+        .agg(
+            tx_count=(COL_AMOUNT, "count"),
+            pct_recurrent=("sig_recurrent", "mean"),
+        )
+        .reset_index()
+    )
     out = (
-        d.assign(tiene_tx=d["tx_count"] > 0, tiene_rec=d["pct_recurrent"] > 0)
+        monthly.assign(tiene_tx=monthly["tx_count"] > 0, tiene_rec=monthly["pct_recurrent"] > 0)
         .groupby("pair", as_index=False)
         .agg(
             meses_con_tx=("tiene_tx", "sum"),
@@ -28,21 +56,22 @@ def empleados_recepcion_constante(reports, min_meses=3):
     return out
 
 
-def desbalance_personas(reports):
-    pers = reports["agg_persona_mensual"].copy()
-    desbalance = (
-        pers.assign(
-            net=pers["sum_emit"] - pers["sum_recv"],
-            ratio=(pers["sum_emit"] / (pers["sum_recv"] + 1e-9)),
-        )
-        .sort_values(["month_id", "net"], ascending=[True, False])
-    )
+def desbalance_personas(reports, timeframe="todo_el_tiempo"):
+    pers = _get_section(reports, "persona", timeframe)
+    if pers.empty:
+        return pers
+    desbalance = pers.assign(
+        net=pers["sum_emit"] - pers["sum_recv"],
+        ratio=(pers["sum_emit"] / (pers["sum_recv"] + 1e-9)),
+    ).sort_values(["net"], ascending=False)
     return desbalance
 
 
-def manager_conceptos_sospechosos(reports, keywords=None):
-    tx = reports["tx_transacciones_priorizadas"].copy()
-    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
+def manager_conceptos_sospechosos(reports, keywords=None, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty:
+        return tx
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)].copy()
     if keywords:
         pat = re.compile("|".join([re.escape(k) for k in keywords]), re.IGNORECASE)
         mgr = mgr[mgr[COL_DESCRIPTION].fillna("").str.contains(pat)]
@@ -57,10 +86,12 @@ def manager_conceptos_sospechosos(reports, keywords=None):
     return agg
 
 
-def centralizadores(reports):
-    tx = reports["tx_transacciones_priorizadas"][
+def centralizadores(reports, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)[
         ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, COL_AMOUNT, "risk_score"]
     ].copy()
+    if tx.empty:
+        return tx
     centro = (
         tx.groupby(["month_id", COL_RECEIVER_ID], as_index=False)
         .agg(
@@ -75,13 +106,18 @@ def centralizadores(reports):
     return centro
 
 
-def yoyo_consecutivos(reports):
-    par = reports["agg_par_mensual"][
-        ["month_id", "pair", "pct_yoyo"]
-    ].copy()
-    par["hit"] = par["pct_yoyo"] > 0
+def yoyo_consecutivos(reports, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty or "month_id" not in tx:
+        return pd.DataFrame(columns=["pair", "tiene_racha_yo_yo"])
+    tmp = tx.copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    monthly = (
+        tmp.groupby(["month_id", "pair"], observed=True)["sig_yoyo"].mean().reset_index(name="pct_yoyo")
+    )
+    monthly["hit"] = monthly["pct_yoyo"] > 0
     out = (
-        par.sort_values(["pair", "month_id"])
+        monthly.sort_values(["pair", "month_id"])
         .groupby("pair")["hit"]
         .apply(lambda s: any(s.shift(1).fillna(False) & s))
         .reset_index(name="tiene_racha_yo_yo")
@@ -89,14 +125,16 @@ def yoyo_consecutivos(reports):
     return out[out["tiene_racha_yo_yo"]]
 
 
-def near_thr_repetido(reports, min_meses=2):
-    tx = reports["tx_transacciones_priorizadas"][
-        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]
-    ].copy()
-    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+def near_thr_repetido(reports, min_meses=2, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty or "month_id" not in tx:
+        return pd.DataFrame(columns=["pair", "meses_con_near"])
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
     near = (
-        tx.groupby(["pair", "month_id"], as_index=False)["sig_near_thr"]
+        tmp.groupby(["pair", "month_id"], observed=True)["sig_near_thr"]
         .mean()
+        .reset_index(name="sig_near_thr")
         .assign(hit=lambda d: d["sig_near_thr"] > 0)
     )
     rep = (
@@ -109,10 +147,12 @@ def near_thr_repetido(reports, min_meses=2):
     return rep
 
 
-def manager_conceptos_riesgo(reports):
-    tx = reports["tx_transacciones_priorizadas"][
+def manager_conceptos_riesgo(reports, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)[
         ["month_id", COL_RELATION, "nlp_concepto_sospechoso", "risk_score"]
     ].copy()
+    if tx.empty:
+        return tx
     mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
     top = (
         mgr.groupby(["month_id", "nlp_concepto_sospechoso"], as_index=False)
@@ -125,14 +165,16 @@ def manager_conceptos_riesgo(reports):
     return top
 
 
-def prestamos_freq_dos_meses(reports, min_meses=2):
-    tx = reports["tx_transacciones_priorizadas"][
-        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]
-    ].copy()
-    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+def prestamos_freq_dos_meses(reports, min_meses=2, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty or "month_id" not in tx:
+        return pd.DataFrame(columns=["pair", "meses_condicion"])
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
     mes_flag = (
-        tx.groupby(["pair", "month_id"], as_index=False)
+        tmp.groupby(["pair", "month_id"], observed=True)
         .agg(loan_bad=("sig_loan_bad_repay", "max"), freq=("sig_freq", "mean"))
+        .reset_index()
         .assign(hit=lambda d: d["loan_bad"] & (d["freq"] > 0))
     )
     candidatos = (
@@ -145,16 +187,20 @@ def prestamos_freq_dos_meses(reports, min_meses=2):
     return candidatos
 
 
-def smurf_cronico(reports, min_meses=3):
-    par = reports["agg_par_mensual"][
-        ["pair", "month_id", "pct_smurf"]
-    ].copy()
-    cron = (
-        par.assign(hit=par["pct_smurf"] > 0)
+def smurf_cronico(reports, min_meses=3, timeframe="todo_el_tiempo"):
+    tx = _get_tx(reports, timeframe)
+    if tx.empty or "month_id" not in tx:
+        return pd.DataFrame(columns=["pair", "meses_smurf"])
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_smurf"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    agg = (
+        tmp.groupby(["pair", "month_id"], observed=True)["sig_smurf"]
+        .mean()
+        .reset_index(name="pct_smurf")
+        .assign(hit=lambda d: d["pct_smurf"] > 0)
         .groupby("pair", as_index=False)["hit"]
         .sum()
         .rename(columns={"hit": "meses_smurf"})
-        .query("meses_smurf >= @min_meses")
         .sort_values("meses_smurf", ascending=False)
     )
-    return cron
+    return agg

--- a/coi_fraud/viz/plots.py
+++ b/coi_fraud/viz/plots.py
@@ -5,63 +5,101 @@ import seaborn as sns
 from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_RELATION, COL_SENDER_ID
 
 
-def plot_constant_receipt_heatmap(reports, ax=None):
-    df = reports["agg_par_mensual"][
-        ["month_id", "pair", "tx_count"]
-    ].copy()
-    pivot = df.pivot_table(
+def _get_section(reports, section, timeframe="todo_el_tiempo"):
+    data = reports.get(section, {})
+    if isinstance(data, dict):
+        df = data.get(timeframe)
+    else:
+        df = data
+    if isinstance(df, pd.DataFrame):
+        out = df.copy()
+        if "timeframe_periodo" in out.columns:
+            out = out.drop(columns=["timeframe_periodo"])
+        return out
+    return pd.DataFrame()
+
+
+def _get_tx(reports, timeframe="todo_el_tiempo"):
+    return _get_section(reports, "transaccion", timeframe)
+
+
+def _ensure_ax(ax):
+    return ax if ax is not None else plt.figure().gca()
+
+
+def plot_constant_receipt_heatmap(reports, timeframe="todo_el_tiempo", ax=None):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty or "month_id" not in tx:
+        ax.set_title(f"Constancia de recepción — {timeframe} (sin datos)")
+        ax.set_xlabel("month_id")
+        ax.set_ylabel("pair")
+        return ax
+    tmp = tx.copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    monthly = (
+        tmp.groupby(["month_id", "pair"], observed=True)[COL_AMOUNT]
+        .count()
+        .reset_index(name="tx_count")
+    )
+    pivot = monthly.pivot_table(
         index="pair",
         columns="month_id",
         values="tx_count",
         fill_value=0,
         aggfunc="sum",
     )
-    ax = ax or plt.figure().gca()
     sns.heatmap(pivot, ax=ax)
-    ax.set_title("Constancia de recepción por par (tx_count por mes)")
+    ax.set_title(f"Constancia de recepción por par — {timeframe}")
     ax.set_xlabel("month_id")
     ax.set_ylabel("pair")
     return ax
 
 
-def plot_person_imbalance_bar(reports, month_id=None, ax=None):
-    df = reports["agg_persona_mensual"].copy()
-    if month_id is None and len(df):
-        month_id = df["month_id"].iloc[0]
-    dd = df[df["month_id"] == month_id].copy()
+def plot_person_imbalance_bar(reports, timeframe="todo_el_tiempo", ax=None, top_n=25):
+    df = _get_section(reports, "persona", timeframe)
+    ax = _ensure_ax(ax)
+    if df.empty:
+        ax.set_title(f"Desbalance emite-recibe — {timeframe} (sin datos)")
+        return ax
+    dd = df.copy()
     dd["net"] = dd["sum_emit"] - dd["sum_recv"]
-    dd = dd.sort_values("net", ascending=False).head(25)
-    ax = ax or plt.figure().gca()
+    dd = dd.sort_values("net", ascending=False).head(top_n)
     sns.barplot(data=dd, x="net", y="persona", ax=ax)
-    ax.set_title(f"Desbalance emite-recibe (top 25) — {month_id}")
+    ax.set_title(f"Desbalance emite-recibe (top {top_n}) — {timeframe}")
     ax.set_xlabel("neto")
     ax.set_ylabel("persona")
     return ax
 
 
-def plot_manager_concepts_bar(reports, month_id=None, ax=None):
-    tx = reports["tx_transacciones_priorizadas"].copy()
-    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
-    if month_id is not None:
-        mgr = mgr[mgr["month_id"] == month_id]
+def plot_manager_concepts_bar(reports, timeframe="todo_el_tiempo", ax=None):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty:
+        ax.set_title(f"Relaciones Manager — conceptos NLP ({timeframe}) sin datos")
+        return ax
+    mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)].copy()
     agg = (
         mgr.groupby("nlp_concepto_sospechoso")[COL_AMOUNT]
         .count()
         .sort_values(ascending=False)
         .reset_index(name="tx_count")
     )
-    ax = ax or plt.figure().gca()
     sns.barplot(data=agg, y="nlp_concepto_sospechoso", x="tx_count", ax=ax)
-    ax.set_title("Relaciones Manager — conceptos NLP")
+    ax.set_title(f"Relaciones Manager — conceptos NLP ({timeframe})")
     ax.set_xlabel("tx_count")
     ax.set_ylabel("concepto")
     return ax
 
 
-def plot_centralizer_scatter(reports, month_id=None, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][
+def plot_centralizer_scatter(reports, timeframe="todo_el_tiempo", ax=None):
+    tx = _get_tx(reports, timeframe)[
         ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, COL_AMOUNT, "risk_score"]
     ].copy()
+    ax = _ensure_ax(ax)
+    if tx.empty:
+        ax.set_title(f"Centralización de inflow — {timeframe} (sin datos)")
+        return ax
     dd = (
         tx.groupby(["month_id", COL_RECEIVER_ID], as_index=False)
         .agg(
@@ -71,10 +109,6 @@ def plot_centralizer_scatter(reports, month_id=None, ax=None):
             risk_avg=("risk_score", "mean"),
         )
     )
-    if month_id is None and len(dd):
-        month_id = dd["month_id"].iloc[0]
-    dd = dd[dd["month_id"] == month_id]
-    ax = ax or plt.figure().gca()
     sns.scatterplot(
         data=dd,
         x="emisores_unicos",
@@ -83,34 +117,47 @@ def plot_centralizer_scatter(reports, month_id=None, ax=None):
         hue="risk_avg",
         ax=ax,
     )
-    ax.set_title(f"Centralización de inflow — {month_id}")
+    ax.set_title(f"Centralización de inflow — {timeframe}")
     ax.set_xlabel("emisores_unicos")
     ax.set_ylabel("inflow")
     return ax
 
 
-def plot_yoyo_pairs_timeline(reports, ax=None):
-    par = reports["agg_par_mensual"][
-        ["month_id", "pair", "pct_yoyo"]
-    ].copy()
-    top_pairs = (
-        par.groupby("pair")["pct_yoyo"].mean().sort_values(ascending=False).head(10).index.tolist()
+def plot_yoyo_pairs_timeline(reports, timeframe="todo_el_tiempo", ax=None, top_n=10):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty or "month_id" not in tx:
+        ax.set_title(f"Yo-Yo por mes — {timeframe} (sin datos)")
+        return ax
+    tmp = tx.copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    monthly = (
+        tmp.groupby(["month_id", "pair"], observed=True)["sig_yoyo"]
+        .mean()
+        .reset_index(name="pct_yoyo")
     )
-    dd = par[par["pair"].isin(top_pairs)]
-    ax = ax or plt.figure().gca()
+    top_pairs = (
+        monthly.groupby("pair")["pct_yoyo"].mean().sort_values(ascending=False).head(top_n).index.tolist()
+    )
+    dd = monthly[monthly["pair"].isin(top_pairs)]
     sns.lineplot(data=dd, x="month_id", y="pct_yoyo", hue="pair", marker="o", ax=ax)
-    ax.set_title("Yo-Yo por mes (top 10 pares)")
+    ax.set_title(f"Yo-Yo por mes (top {top_n} pares) — {timeframe}")
     ax.set_xlabel("month_id")
     ax.set_ylabel("pct_yoyo")
     return ax
 
 
-def plot_near_threshold_heatmap(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][
-        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]
-    ].copy()
-    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
-    near = tx.groupby(["pair", "month_id"], as_index=False)["sig_near_thr"].mean()
+def plot_near_threshold_heatmap(reports, timeframe="todo_el_tiempo", ax=None):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty or "month_id" not in tx:
+        ax.set_title(f"Cerca de umbral — {timeframe} (sin datos)")
+        ax.set_xlabel("month_id")
+        ax.set_ylabel("pair")
+        return ax
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_near_thr"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
+    near = tmp.groupby(["pair", "month_id"], observed=True)["sig_near_thr"].mean().reset_index()
     pivot = near.pivot_table(
         index="pair",
         columns="month_id",
@@ -118,18 +165,21 @@ def plot_near_threshold_heatmap(reports, ax=None):
         fill_value=0,
         aggfunc="mean",
     )
-    ax = ax or plt.figure().gca()
     sns.heatmap(pivot, ax=ax)
-    ax.set_title("Cerca de umbral — intensidad por par/mes")
+    ax.set_title(f"Cerca de umbral — intensidad por par/mes ({timeframe})")
     ax.set_xlabel("month_id")
     ax.set_ylabel("pair")
     return ax
 
 
-def plot_manager_concepts_risk(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][
+def plot_manager_concepts_risk(reports, timeframe="todo_el_tiempo", ax=None):
+    tx = _get_tx(reports, timeframe)[
         ["month_id", COL_RELATION, "nlp_concepto_sospechoso", "risk_score"]
     ].copy()
+    ax = _ensure_ax(ax)
+    if tx.empty:
+        ax.set_title(f"Manager: conceptos vs severidad ({timeframe}) sin datos")
+        return ax
     mgr = tx[tx[COL_RELATION].str.contains("Manager", case=False, na=False)]
     agg = (
         mgr.groupby(["month_id", "nlp_concepto_sospechoso"], as_index=False)
@@ -138,7 +188,6 @@ def plot_manager_concepts_risk(reports, ax=None):
             risk_p95=("risk_score", lambda s: float(s.quantile(0.95)) if len(s) else 0.0),
         )
     )
-    ax = ax or plt.figure().gca()
     sns.scatterplot(
         data=agg,
         x="risk_p95",
@@ -147,20 +196,24 @@ def plot_manager_concepts_risk(reports, ax=None):
         style="month_id",
         ax=ax,
     )
-    ax.set_title("Manager: conceptos vs severidad (p95)")
+    ax.set_title(f"Manager: conceptos vs severidad (p95) — {timeframe}")
     ax.set_xlabel("risk_p95")
     ax.set_ylabel("tx_count")
     return ax
 
 
-def plot_loan_freq_dual(reports, ax=None):
-    tx = reports["tx_transacciones_priorizadas"][
-        ["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]
-    ].copy()
-    tx["pair"] = tx[COL_SENDER_ID] + "→" + tx[COL_RECEIVER_ID]
+def plot_loan_freq_dual(reports, timeframe="todo_el_tiempo", ax=None, top_n=25):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty or "month_id" not in tx:
+        ax.set_title(f"Préstamo sin repago + alta frecuencia — {timeframe} (sin datos)")
+        return ax
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_loan_bad_repay", "sig_freq"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
     mes_flag = (
-        tx.groupby(["pair", "month_id"], as_index=False)
+        tmp.groupby(["pair", "month_id"], observed=True)
         .agg(loan_bad=("sig_loan_bad_repay", "max"), freq=("sig_freq", "mean"))
+        .reset_index()
         .assign(hit=lambda d: d["loan_bad"] & (d["freq"] > 0))
     )
     agg = (
@@ -168,31 +221,36 @@ def plot_loan_freq_dual(reports, ax=None):
         .sum()
         .rename(columns={"hit": "meses_condicion"})
         .sort_values("meses_condicion", ascending=False)
-        .head(25)
+        .head(top_n)
     )
-    ax = ax or plt.figure().gca()
     sns.barplot(data=agg, x="meses_condicion", y="pair", ax=ax)
-    ax.set_title("Préstamo sin repago + alta frecuencia")
+    ax.set_title(f"Préstamo sin repago + alta frecuencia — {timeframe}")
     ax.set_xlabel("meses_condicion")
     ax.set_ylabel("pair")
     return ax
 
 
-def plot_smurf_chronic(reports, ax=None):
-    par = reports["agg_par_mensual"][
-        ["pair", "month_id", "pct_smurf"]
-    ].copy()
+def plot_smurf_chronic(reports, timeframe="todo_el_tiempo", ax=None, top_n=25):
+    tx = _get_tx(reports, timeframe)
+    ax = _ensure_ax(ax)
+    if tx.empty or "month_id" not in tx:
+        ax.set_title(f"Smurfing crónico — {timeframe} (sin datos)")
+        return ax
+    tmp = tx[["month_id", COL_SENDER_ID, COL_RECEIVER_ID, "sig_smurf"]].copy()
+    tmp["pair"] = tmp[COL_SENDER_ID].astype(str) + "→" + tmp[COL_RECEIVER_ID].astype(str)
     agg = (
-        par.assign(hit=par["pct_smurf"] > 0)
+        tmp.groupby(["pair", "month_id"], observed=True)["sig_smurf"]
+        .mean()
+        .reset_index(name="pct_smurf")
+        .assign(hit=lambda d: d["pct_smurf"] > 0)
         .groupby("pair", as_index=False)["hit"]
         .sum()
         .rename(columns={"hit": "meses_smurf"})
         .sort_values("meses_smurf", ascending=False)
-        .head(25)
+        .head(top_n)
     )
-    ax = ax or plt.figure().gca()
     sns.barplot(data=agg, x="meses_smurf", y="pair", ax=ax)
-    ax.set_title("Smurfing crónico (meses con señal)")
+    ax.set_title(f"Smurfing crónico (meses con señal) — {timeframe}")
     ax.set_xlabel("meses_smurf")
     ax.set_ylabel("pair")
     return ax


### PR DESCRIPTION
## Summary
- restructure aggregated report generation to slice data by key timeframes and attach timeframe metadata
- add NLP-aware concept, person, pair, and new cluster summaries with descriptive indicator columns
- update QA helpers and visualization functions to consume the new report structure and timeframe filters

## Testing
- python -m compileall coi_fraud

------
https://chatgpt.com/codex/tasks/task_e_68dd8d690288832ca702dd6961c6c34d