### PR TITLE
Add persistent imbalance and burst channel indicators

### DIFF
--- a/coi_fraud/aggregate/bursts.py
+++ b/coi_fraud/aggregate/bursts.py
@@ -1,0 +1,76 @@
+import pandas as pd
+
+from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+
+
+def build_burst_report(df: pd.DataFrame) -> pd.DataFrame:
+    required_cols = {
+        "rafaga_canal_flag_evento",
+        "rafaga_canal_id",
+        "rafaga_canal_hora_bin_inicio",
+    }
+    if df.empty or not required_cols.issubset(df.columns):
+        return _empty_report()
+
+    flagged = df[df["rafaga_canal_flag_evento"].fillna(False)].copy()
+    if flagged.empty:
+        return _empty_report()
+
+    grouped = (
+        flagged.groupby(["rafaga_canal_id", "rafaga_canal_hora_bin_inicio"], observed=True)
+        .agg(
+            rafaga_canal_hora_bin_fin=("rafaga_canal_hora_bin_fin", "first"),
+            rafaga_canal_hora_label=("rafaga_canal_hora_label", "first"),
+            rafaga_canal_tx_en_bin=("rafaga_canal_tx_en_bin", "first"),
+            rafaga_canal_tx_fuera_horario=("rafaga_canal_tx_fuera_horario", "first"),
+            rafaga_canal_ratio_fuera_horario=("rafaga_canal_ratio_fuera_horario", "first"),
+            rafaga_canal_monto_total=(COL_AMOUNT, "sum"),
+            rafaga_canal_monto_promedio=(COL_AMOUNT, "mean"),
+            rafaga_canal_personas_emisoras=(COL_SENDER_ID, "nunique"),
+            rafaga_canal_personas_receptoras=(COL_RECEIVER_ID, "nunique"),
+            rafaga_canal_riesgo_prom=("risk_score", "mean"),
+            rafaga_canal_riesgo_max=("risk_score", "max"),
+        )
+        .reset_index()
+    )
+
+    grouped = grouped.sort_values(
+        ["rafaga_canal_tx_en_bin", "rafaga_canal_monto_total"], ascending=[False, False]
+    )
+
+    return grouped[
+        [
+            "rafaga_canal_id",
+            "rafaga_canal_hora_bin_inicio",
+            "rafaga_canal_hora_bin_fin",
+            "rafaga_canal_hora_label",
+            "rafaga_canal_tx_en_bin",
+            "rafaga_canal_tx_fuera_horario",
+            "rafaga_canal_ratio_fuera_horario",
+            "rafaga_canal_monto_total",
+            "rafaga_canal_monto_promedio",
+            "rafaga_canal_personas_emisoras",
+            "rafaga_canal_personas_receptoras",
+            "rafaga_canal_riesgo_prom",
+            "rafaga_canal_riesgo_max",
+        ]
+    ]
+
+
+def _empty_report() -> pd.DataFrame:
+    cols = [
+        "rafaga_canal_id",
+        "rafaga_canal_hora_bin_inicio",
+        "rafaga_canal_hora_bin_fin",
+        "rafaga_canal_hora_label",
+        "rafaga_canal_tx_en_bin",
+        "rafaga_canal_tx_fuera_horario",
+        "rafaga_canal_ratio_fuera_horario",
+        "rafaga_canal_monto_total",
+        "rafaga_canal_monto_promedio",
+        "rafaga_canal_personas_emisoras",
+        "rafaga_canal_personas_receptoras",
+        "rafaga_canal_riesgo_prom",
+        "rafaga_canal_riesgo_max",
+    ]
+    return pd.DataFrame(columns=cols)

--- a/coi_fraud/aggregate/persons.py
+++ b/coi_fraud/aggregate/persons.py
@@ -8,6 +8,15 @@ def _ensure_string(series: pd.Series) -> pd.Series:
     return series.fillna("").astype("string").str.strip()
 
 
+def _safe_zscore(series: pd.Series) -> pd.Series:
+    values = series.astype(float)
+    mean = values.mean()
+    std = values.std(ddof=0)
+    if pd.isna(std) or std == 0:
+        return pd.Series(0.0, index=values.index, dtype="float64")
+    return (values - mean) / std
+
+
 def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
     if df.empty:
         return pd.DataFrame(
@@ -31,6 +40,14 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
                 "nlp_persona_top_conceptos",
                 "desbalance_persona_monto_neto",
                 "desbalance_persona_ratio_emision_vs_recepcion",
+                "desbalance_persona_zscore_emision_total",
+                "desbalance_persona_zscore_recepcion_total",
+                "desbalance_persona_zscore_neto_total",
+                "desbalance_persona_meses_totales",
+                "desbalance_persona_meses_envia_extremo",
+                "desbalance_persona_meses_recibe_extremo",
+                "desbalance_persona_tasa_meses_envia_extremo",
+                "desbalance_persona_tasa_meses_recibe_extremo",
                 "yo_yo_persona_tasa_flag_emisor",
                 "smurf_persona_tasa_flag_emisor",
                 "frecuencia_persona_tasa_flag_emisor",
@@ -199,6 +216,106 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
     total_mov = people["sum_emit"] + people["sum_recv"]
     people["desbalance_persona_ratio_emision_vs_recepcion"] = (
         people["sum_emit"].where(total_mov == 0, people["sum_emit"] / total_mov)
+    )
+    people["desbalance_persona_zscore_emision_total"] = _safe_zscore(people["sum_emit"])
+    people["desbalance_persona_zscore_recepcion_total"] = _safe_zscore(people["sum_recv"])
+    people["desbalance_persona_zscore_neto_total"] = _safe_zscore(
+        people["desbalance_persona_monto_neto"]
+    )
+
+    monthly_cols = [
+        "desbalance_persona_meses_totales",
+        "desbalance_persona_meses_envia_extremo",
+        "desbalance_persona_meses_recibe_extremo",
+        "desbalance_persona_tasa_meses_envia_extremo",
+        "desbalance_persona_tasa_meses_recibe_extremo",
+    ]
+    if "month_id" in df.columns:
+        em_month = (
+            df.groupby(["month_id", COL_SENDER_ID], observed=True)
+            .agg(
+                sum_emit_mes=(COL_AMOUNT, "sum"),
+                n_tx_emit_mes=(COL_AMOUNT, "count"),
+            )
+            .reset_index()
+            .rename(columns={COL_SENDER_ID: "persona"})
+        )
+        re_month = (
+            df.groupby(["month_id", COL_RECEIVER_ID], observed=True)
+            .agg(
+                sum_recv_mes=(COL_AMOUNT, "sum"),
+                n_tx_recv_mes=(COL_AMOUNT, "count"),
+            )
+            .reset_index()
+            .rename(columns={COL_RECEIVER_ID: "persona"})
+        )
+        monthly = em_month.merge(re_month, on=["month_id", "persona"], how="outer").fillna(
+            {
+                "sum_emit_mes": 0.0,
+                "n_tx_emit_mes": 0,
+                "sum_recv_mes": 0.0,
+                "n_tx_recv_mes": 0,
+            }
+        )
+        monthly = monthly[
+            (monthly["n_tx_emit_mes"] > 0) | (monthly["n_tx_recv_mes"] > 0)
+        ].copy()
+        if not monthly.empty:
+            monthly["desbalance_mes_neto"] = (
+                monthly["sum_emit_mes"] - monthly["sum_recv_mes"]
+            )
+            monthly["z_emit_mes"] = monthly.groupby("month_id", observed=True)[
+                "sum_emit_mes"
+            ].transform(_safe_zscore)
+            monthly["z_recv_mes"] = monthly.groupby("month_id", observed=True)[
+                "sum_recv_mes"
+            ].transform(_safe_zscore)
+            monthly["z_neto_mes"] = monthly.groupby("month_id", observed=True)[
+                "desbalance_mes_neto"
+            ].transform(_safe_zscore)
+            monthly["flag_envia_extremo"] = (
+                (monthly["desbalance_mes_neto"] > 0)
+                & (monthly["z_neto_mes"].abs() >= 2.0)
+            )
+            monthly["flag_recibe_extremo"] = (
+                (monthly["desbalance_mes_neto"] < 0)
+                & (monthly["z_neto_mes"].abs() >= 2.0)
+            )
+            monthly_stats = (
+                monthly.groupby("persona", observed=True)
+                .agg(
+                    desbalance_persona_meses_totales=("month_id", "nunique"),
+                    desbalance_persona_meses_envia_extremo=("flag_envia_extremo", "sum"),
+                    desbalance_persona_meses_recibe_extremo=("flag_recibe_extremo", "sum"),
+                )
+                .reset_index()
+            )
+            monthly_stats["desbalance_persona_tasa_meses_envia_extremo"] = (
+                monthly_stats["desbalance_persona_meses_envia_extremo"]
+                / monthly_stats["desbalance_persona_meses_totales"].replace({0: pd.NA})
+            ).fillna(0.0)
+            monthly_stats["desbalance_persona_tasa_meses_recibe_extremo"] = (
+                monthly_stats["desbalance_persona_meses_recibe_extremo"]
+                / monthly_stats["desbalance_persona_meses_totales"].replace({0: pd.NA})
+            ).fillna(0.0)
+            people = people.merge(monthly_stats, on="persona", how="left")
+    for col in monthly_cols:
+        if col not in people:
+            people[col] = 0
+    people["desbalance_persona_meses_totales"] = (
+        people["desbalance_persona_meses_totales"].fillna(0).astype("Int64")
+    )
+    people["desbalance_persona_meses_envia_extremo"] = (
+        people["desbalance_persona_meses_envia_extremo"].fillna(0).astype("Int64")
+    )
+    people["desbalance_persona_meses_recibe_extremo"] = (
+        people["desbalance_persona_meses_recibe_extremo"].fillna(0).astype("Int64")
+    )
+    people["desbalance_persona_tasa_meses_envia_extremo"] = (
+        people["desbalance_persona_tasa_meses_envia_extremo"].fillna(0.0).astype(float)
+    )
+    people["desbalance_persona_tasa_meses_recibe_extremo"] = (
+        people["desbalance_persona_tasa_meses_recibe_extremo"].fillna(0.0).astype(float)
     )
 
     if "nlp_persona_top_conceptos" in people:

--- a/coi_fraud/aggregate/reports.py
+++ b/coi_fraud/aggregate/reports.py
@@ -12,6 +12,7 @@ from .transactions import build_tx_table
 from .quid import build_quid_tables
 from .reference_reuse import build_reference_reuse_tables
 from .change_points import build_change_point_tables
+from .bursts import build_burst_report
 
 
 TIME_WINDOWS = {
@@ -56,6 +57,7 @@ def build_all_reports(df: pd.DataFrame):
         "casuistica_referencia_tx": {},
         "casuistica_cambio_brusco_eventos": {},
         "casuistica_cambio_brusco_pares": {},
+        "casuistica_rafagas_canal": {},
     }
     for label, window in TIME_WINDOWS.items():
         sliced = _slice_timeframe(df, window)
@@ -76,6 +78,7 @@ def build_all_reports(df: pd.DataFrame):
         chg_events, chg_pairs = build_change_point_tables(sliced)
         chg_events = _tag_timeframe(chg_events, label)
         chg_pairs = _tag_timeframe(chg_pairs, label)
+        bursts = _tag_timeframe(build_burst_report(sliced), label)
         outputs["transaccion"][label] = tx
         outputs["persona"][label] = persons
         outputs["par_personas"][label] = pairs
@@ -89,4 +92,5 @@ def build_all_reports(df: pd.DataFrame):
         outputs["casuistica_referencia_tx"][label] = ref_tx
         outputs["casuistica_cambio_brusco_eventos"][label] = chg_events
         outputs["casuistica_cambio_brusco_pares"][label] = chg_pairs
+        outputs["casuistica_rafagas_canal"][label] = bursts
     return outputs

--- a/coi_fraud/config.py
+++ b/coi_fraud/config.py
@@ -13,6 +13,11 @@ class Params:
     freq_window_days: int = 30
     freq_pair_threshold: int = 5
     recurrent_months_min: int = 3
+    burst_bin_hours: int = 2
+    burst_min_tx: int = 5
+    burst_work_start_hour: int = 8
+    burst_work_end_hour: int = 20
+    burst_min_off_hours_ratio: float = 0.6
     near_thresholds: List[float] = field(default_factory=lambda: [500, 1000, 2000, 5000, 10000])
     near_delta: float = 10.0
     round_bases: List[int] = field(default_factory=lambda: [10, 50, 100, 500, 1000])

--- a/coi_fraud/features/burst.py
+++ b/coi_fraud/features/burst.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+
+import pandas as pd
+
+from ..schemas import (
+    COL_AMOUNT,
+    COL_ORIGIN_APP,
+    COL_RECEIVER_ID,
+    COL_SENDER_ID,
+)
+
+
+def _format_bin_label(start: pd.Series, end: pd.Series) -> pd.Series:
+    start_fmt = start.dt.strftime("%Y-%m-%d %H:%M")
+    end_fmt = end.dt.strftime("%H:%M")
+    return start_fmt.str.cat(end_fmt, sep=" - ")
+
+
+@dataclass
+class BurstDetectorConfig:
+    bin_hours: int
+    min_tx: int
+    work_start_hour: int
+    work_end_hour: int
+    min_off_hours_ratio: float
+
+
+class BurstDetector:
+    def __init__(self, config: BurstDetectorConfig):
+        self.config = config
+
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty or "fecha_hora_ts" not in df:
+            return self._ensure_output_columns(df)
+
+        work = df.copy()
+
+        if COL_ORIGIN_APP not in work:
+            work[COL_ORIGIN_APP] = pd.NA
+
+        canal = work[COL_ORIGIN_APP].astype("string").str.strip()
+        canal = canal.replace({"": pd.NA})
+        work[COL_ORIGIN_APP] = canal
+        work["rafaga_canal_id"] = canal.fillna("sin_canal")
+
+        ts = pd.to_datetime(work["fecha_hora_ts"], errors="coerce")
+        bin_td = pd.Timedelta(hours=self.config.bin_hours)
+        work["rafaga_canal_hora_bin_inicio"] = ts.dt.floor(f"{self.config.bin_hours}H")
+        work["rafaga_canal_hora_bin_fin"] = work["rafaga_canal_hora_bin_inicio"] + bin_td
+        work["rafaga_canal_hora_label"] = _format_bin_label(
+            work["rafaga_canal_hora_bin_inicio"], work["rafaga_canal_hora_bin_fin"]
+        )
+
+        hour = ts.dt.hour
+        off_hours = (hour < self.config.work_start_hour) | (hour >= self.config.work_end_hour)
+        work["rafaga_canal_flag_fuera_horario"] = off_hours.fillna(False)
+
+        group_cols = ["rafaga_canal_id", "rafaga_canal_hora_bin_inicio"]
+        stats = (
+            work.groupby(group_cols, observed=True)
+            .agg(
+                rafaga_canal_hora_bin_fin=("rafaga_canal_hora_bin_fin", "first"),
+                rafaga_canal_hora_label=("rafaga_canal_hora_label", "first"),
+                rafaga_canal_tx_en_bin=(COL_AMOUNT, "count"),
+                rafaga_canal_tx_fuera_horario=("rafaga_canal_flag_fuera_horario", "sum"),
+                rafaga_canal_personas_emisoras=(COL_SENDER_ID, "nunique"),
+                rafaga_canal_personas_receptoras=(COL_RECEIVER_ID, "nunique"),
+                rafaga_canal_monto_total=(COL_AMOUNT, "sum"),
+            )
+            .reset_index()
+        )
+
+        if not stats.empty:
+            stats["rafaga_canal_ratio_fuera_horario"] = (
+                stats["rafaga_canal_tx_fuera_horario"]
+                / stats["rafaga_canal_tx_en_bin"].replace({0: pd.NA})
+            ).fillna(0.0)
+            stats["rafaga_canal_flag_evento"] = (
+                (stats["rafaga_canal_tx_en_bin"] >= self.config.min_tx)
+                & (stats["rafaga_canal_ratio_fuera_horario"] >= self.config.min_off_hours_ratio)
+            )
+        else:
+            stats["rafaga_canal_ratio_fuera_horario"] = pd.Series(dtype="float64")
+            stats["rafaga_canal_flag_evento"] = pd.Series(dtype="boolean")
+
+        work = work.merge(stats, on=group_cols, how="left")
+
+        return self._ensure_output_columns(work)
+
+    @staticmethod
+    def _ensure_output_columns(df: pd.DataFrame) -> pd.DataFrame:
+        required = {
+            COL_ORIGIN_APP: "string",
+            "rafaga_canal_id": "string",
+            "rafaga_canal_hora_bin_inicio": "datetime64[ns]",
+            "rafaga_canal_hora_bin_fin": "datetime64[ns]",
+            "rafaga_canal_hora_label": "string",
+            "rafaga_canal_tx_en_bin": "Int64",
+            "rafaga_canal_tx_fuera_horario": "Int64",
+            "rafaga_canal_ratio_fuera_horario": "float64",
+            "rafaga_canal_personas_emisoras": "Int64",
+            "rafaga_canal_personas_receptoras": "Int64",
+            "rafaga_canal_monto_total": "float64",
+            "rafaga_canal_flag_evento": "boolean",
+            "rafaga_canal_flag_fuera_horario": "boolean",
+        }
+        if df.empty:
+            for col, dtype in required.items():
+                if col not in df:
+                    df[col] = pd.Series(dtype=dtype)
+            return df
+        for col, dtype in required.items():
+            if col not in df:
+                df[col] = pd.Series(pd.NA, index=df.index, dtype=dtype)
+        return df

--- a/coi_fraud/io/ingest.py
+++ b/coi_fraud/io/ingest.py
@@ -119,6 +119,13 @@ def ingest_df(df: pd.DataFrame) -> pd.DataFrame:
     _ensure_columns(df, raw_required)
     df = df.copy()
 
+    origin_col = "origin_application_id"
+    if origin_col in df.columns:
+        df[origin_col] = df[origin_col].astype("string").str.strip()
+        df[origin_col] = df[origin_col].replace({"": pd.NA})
+    else:
+        df[origin_col] = pd.NA
+
     df[COL_AMOUNT] = pd.to_numeric(df[COL_AMOUNT], errors="coerce")
     df[COL_DATETIME] = _parse_load_datetime(df[LOAD_DATE_COL])
 

--- a/coi_fraud/pipeline.py
+++ b/coi_fraud/pipeline.py
@@ -13,6 +13,7 @@ from .features.recurrent import MonthlyRecurrentDetector
 from .features.quid import QuidProQuoConfig, QuidProQuoDetector
 from .features.reference_reuse import ReferenceReuseConfig, ReferenceReuseDetector
 from .features.change_points import ChangePointConfig, ChangePointDetector
+from .features.burst import BurstDetector, BurstDetectorConfig
 from .features.sna_light import transform as sna_light
 from .features.holidays import holiday_proximity
 from .features.nlp_mx import apply_nlp
@@ -31,6 +32,15 @@ def run_pipeline(df, language="es"):
         LoanRepayDetector(P.loan_repay_days, P.loan_min_repay_ratio),
         FrequencyDetector(P.freq_window_days, P.freq_pair_threshold),
         MonthlyRecurrentDetector(P.recurrent_months_min),
+        BurstDetector(
+            BurstDetectorConfig(
+                bin_hours=P.burst_bin_hours,
+                min_tx=P.burst_min_tx,
+                work_start_hour=P.burst_work_start_hour,
+                work_end_hour=P.burst_work_end_hour,
+                min_off_hours_ratio=P.burst_min_off_hours_ratio,
+            )
+        ),
         QuidProQuoDetector(
             QuidProQuoConfig(
                 window_days=P.quid_window_days,

--- a/coi_fraud/schemas.py
+++ b/coi_fraud/schemas.py
@@ -4,6 +4,7 @@ COL_RELATION = "relacion"
 COL_DATETIME = "fecha_hora"
 COL_AMOUNT = "movement_amount"
 COL_DESCRIPTION = "descripcion"
+COL_ORIGIN_APP = "origin_application_id"
 
 COL_SENDER_FULL_NAME = "user_nombre_completo"
 COL_RECEIVER_FULL_NAME = "receptor_nombre_completo"
@@ -82,4 +83,17 @@ TX_COLS_EXPORT = [
     "feat_nlp_risk_points",
     "feat_nlp_vaguedad",
     "feat_nlp_emocion",
+    COL_ORIGIN_APP,
+    "rafaga_canal_id",
+    "rafaga_canal_hora_bin_inicio",
+    "rafaga_canal_hora_bin_fin",
+    "rafaga_canal_hora_label",
+    "rafaga_canal_tx_en_bin",
+    "rafaga_canal_tx_fuera_horario",
+    "rafaga_canal_ratio_fuera_horario",
+    "rafaga_canal_personas_emisoras",
+    "rafaga_canal_personas_receptoras",
+    "rafaga_canal_monto_total",
+    "rafaga_canal_flag_evento",
+    "rafaga_canal_flag_fuera_horario",
 ]


### PR DESCRIPTION
## Summary
- compute person-level imbalance z-scores and persistence ratios to highlight sustained emit/receive gaps
- capture origin application metadata, detect off-hour channel bursts, and expose results in transaction exports and a dedicated report

## Testing
- python -m compileall coi_fraud

------
https://chatgpt.com/codex/tasks/task_e_68dd978d7a08832ca759ef55a96464af