### PR TITLE
Add seaborn visualizations for experiment questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,30 +125,100 @@ El módulo `experiment_questions.py` genera respuestas tabulares para siete preg
 - **Q1 – Manager con conceptos NLP sospechosos** (`question1_manager_nlp`):
   - **Metodología:** filtra transacciones manager-subordinado en `reports["transaccion"][timeframe]`, concatena campos `nlp_concepto_sospechoso`, `descripcion` y `tx_tags`, y ejecuta coincidencias por expresiones regulares contra las categorías `("SOBORNO", "FACILITACIÓN", "OFUSCACIÓN", "EXTORSIÓN", "FAVORES SEXUALES")` y sus sinónimos (`NLP_CATEGORY_SYNONYMS`). Agrupa por mes, categoría detectada, manager y subordinado para resumir `tx_count` y `monto_total` y generar textos explicativos.
   - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores).
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q1_manager_nlp
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plot_q1_manager_nlp(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q2 – Conceptos NLP con mayor severidad** (`question2_manager_concepts`):
   - **Metodología:** reutiliza la detección de Q1 sobre `reports["transaccion"][timeframe]` y agrega por mes y categoría calculando número de transacciones y el cuantil 0.95 de `risk_score`, ordenando por severidad antes de redactar la explicación.
   - **Parámetros clave:** `timeframe`; categorías NLP internas (idénticas a Q1, sin exponer otro parámetro).
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q2_manager_concepts
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plot_q2_manager_concepts(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q3 – Pares con rasgos Quid Pro Quo** (`question3_quid_pairs`):
   - **Metodología:** parte del resumen `reports["casuistica_quid_pro_quo_par"][timeframe]` y del detalle `reports["casuistica_quid_pro_quo_tx"][timeframe]` (o de `transaccion` si faltan). Selecciona pares con `quid_score_max ≥ min_score` (2.2 por defecto), proporción de interacciones jerárquicas (`quid_manager_ratio`) superior a `min_manager_ratio` (0.5) y alguna aprobación o compensación. Si no hay resultados, recurre a las transacciones base calculando agregados por par, con un modo relajado que prioriza los puntajes más altos disponibles. Complementa con un listado de transacciones destacadas por `feat_quid_score` y, si fue necesario, con umbrales relajados.
   - **Parámetros clave:** `timeframe`; `min_score` (float, 2.2 por defecto); `min_manager_ratio` (float, 0.5 por defecto).
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q3_quid_pairs
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q3_quid_pairs(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q4 – Autorizaciones con valor negativo vs. carga** (`question4_quid_negative_value_vs_load`):
   - **Metodología:** inspecciona `casuistica_quid_pro_quo_tx` (o `transaccion` como respaldo) buscando transacciones con `feat_quid_value_vs_load_days < 0`. Si no existen, selecciona las 10 con menores desfases registrados o, en su defecto, los mayores puntajes `feat_quid_score`. Calcula el posible responsable según la relación jerárquica (`relacion`/`feat_quid_rel_label`) y redacta el resumen indicando desfase, puntaje y responsable identificado; marca explícitamente cuando se usó el criterio relajado.
   - **Parámetros clave:** `timeframe`.
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q4_negative_value_vs_load
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q4_negative_value_vs_load(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q5 – Reutilización de referencias de pago** (`question5_reference_reuse`):
   - **Metodología:** trabaja con `casuistica_referencia_resumen` y `casuistica_referencia_tx`. Prioriza referencias que aparezcan en más de un par (`n_pairs > 1`), ordenadas por número de pares, rango de días (`days_range`) y transacciones. Si esos datos no existen, reconstruye la métrica desde `transaccion` usando `feat_reference_norm` (o normalizando `descripcion`), calcula métricas temporales y filtra por reutilización en ≤30 días; de no haber candidatos, activa un modo relajado que lista las referencias más frecuentes. Finalmente, detalla las transacciones asociadas a cada referencia recurrente.
   - **Parámetros clave:** `timeframe` (el resto de umbrales y normalizaciones están codificados en la función; no se exponen parámetros adicionales).
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q5_reference_reuse
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q5_reference_reuse(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q6 – Receptores centralizadores** (`question6_centralizers`):
   - **Metodología:** resume `reports["transaccion"][timeframe]` por mes y receptor (`receptor-user_id`), calculando el `inflow` total, emisores únicos, número de transacciones y riesgo promedio (`risk_score`). Define una métrica de `centralidad = inflow * emisores_unicos`, ordena de mayor a menor por mes y genera explicaciones con esos indicadores.
   - **Parámetros clave:** `timeframe`.
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q6_centralizers
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q6_centralizers(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 - **Q7 – Personas con desbalance neto** (`question7_net_imbalance`):
   - **Metodología:** toma `reports["persona"][timeframe]`, asegura la presencia de `desbalance_persona_monto_neto`, calcula su valor absoluto para ordenar y conserva también los contadores de meses extremos enviando y recibiendo. Produce interpretabilidad destacando el desbalance monetario y los meses con comportamiento extremo.
   - **Parámetros clave:** `timeframe`.
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q7_net_imbalance
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plot_q7_net_imbalance(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
 
 ## CLI
 ```bash

--- a/experiment_visualizations.py
+++ b/experiment_visualizations.py
@@ -1,0 +1,303 @@
+"""Visualizaciones con Seaborn para las preguntas de `experiment_questions`."""
+from __future__ import annotations
+
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import seaborn as sns
+from matplotlib.axes import Axes
+
+from coi_fraud.schemas import COL_RECEIVER_ID, COL_SENDER_ID
+from experiment_questions import (
+    DEFAULT_TIMEFRAME,
+    question1_manager_nlp,
+    question2_manager_concepts,
+    question3_quid_pairs,
+    question4_quid_negative_value_vs_load,
+    question5_reference_reuse,
+    question6_centralizers,
+    question7_net_imbalance,
+)
+
+
+sns.set_theme(style="whitegrid")
+
+
+def _ensure_axis(ax: Optional[Axes] = None, figsize: tuple[int, int] = (8, 5)) -> Axes:
+    if ax is not None:
+        return ax
+    _, created_ax = plt.subplots(figsize=figsize)
+    return created_ax
+
+
+def _empty_chart(ax: Axes, title: str, message: str) -> Axes:
+    ax.set_title(title)
+    ax.text(0.5, 0.5, message, ha="center", va="center", transform=ax.transAxes)
+    ax.set_axis_off()
+    return ax
+
+
+def plot_q1_manager_nlp(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica los pares manager-subordinado con conceptos NLP sospechosos."""
+    data = question1_manager_nlp(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q1 – Conceptos sospechosos",
+            "Sin coincidencias manager-subordinado para el periodo seleccionado.",
+        )
+
+    work = data.copy()
+    work["pair"] = (
+        work["manager_user_id"].fillna("sin_manager").astype(str)
+        + "→"
+        + work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
+    )
+    work = work.sort_values(["tx_count", "monto_total"], ascending=[False, False]).head(top_n)
+
+    sns.barplot(data=work, x="tx_count", y="pair", hue="nlp_concepto_sospechoso", ax=axis)
+    axis.set_title(f"Q1 – Pares con conceptos sospechosos ({timeframe})")
+    axis.set_xlabel("Número de transacciones")
+    axis.set_ylabel("Manager → Subordinado")
+    axis.legend(title="Concepto")
+    return axis
+
+
+def plot_q2_manager_concepts(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 8,
+) -> Axes:
+    """Grafica conceptos NLP por severidad (P95)."""
+    data = question2_manager_concepts(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q2 – Severidad NLP",
+            "Sin conceptos con severidad calculada para el periodo.",
+        )
+
+    work = data.copy()
+    work = work.sort_values(["risk_p95", "tx_count"], ascending=[False, False]).head(top_n)
+    plot_kwargs = {
+        "data": work,
+        "x": "risk_p95",
+        "y": "nlp_concepto_sospechoso",
+        "ax": axis,
+    }
+    if "month_id" in work:
+        plot_kwargs["hue"] = "month_id"
+    sns.barplot(**plot_kwargs)
+    if axis.get_legend() is not None:
+        axis.legend(title="Mes")
+    axis.set_title(f"Q2 – Severidad por concepto ({timeframe})")
+    axis.set_xlabel("P95 de risk_score")
+    axis.set_ylabel("Concepto NLP")
+    return axis
+
+
+def plot_q3_quid_pairs(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pares destacados por puntaje quid-pro-quo."""
+    data = question3_quid_pairs(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q3 – Pares Quid Pro Quo",
+            "Sin pares destacados para el periodo.",
+        )
+
+    work = data.copy()
+    if "nivel_respuesta" in work.columns:
+        work = work.loc[work["nivel_respuesta"] == "par"].copy()
+    if work.empty:
+        return _empty_chart(
+            axis,
+            "Q3 – Pares Quid Pro Quo",
+            "Solo se encontraron detalles de transacción, no pares agregados.",
+        )
+
+    work["label"] = (
+        work.get("quid_pair_label", work.get("quid_pair_clave", "sin_par"))
+        .fillna("sin_par")
+        .astype(str)
+    )
+    work = work.sort_values(["quid_score_max", "quid_tx_count"], ascending=[False, False]).head(top_n)
+    sns.barplot(data=work, x="quid_score_max", y="label", hue="quid_tx_count", ax=axis)
+    axis.set_title(f"Q3 – Pares con mayor puntaje ({timeframe})")
+    axis.set_xlabel("Puntaje máximo quid-pro-quo")
+    axis.set_ylabel("Par emisor → receptor")
+    axis.legend(title="Transacciones")
+    return axis
+
+
+def plot_q4_negative_value_vs_load(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica transacciones con desfase negativo autorización vs. carga."""
+    data = question4_quid_negative_value_vs_load(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q4 – Autorización vs. carga",
+            "Sin transacciones con desfase negativo registradas.",
+        )
+
+    work = data.copy()
+    work = work.sort_values("feat_quid_value_vs_load_days", ascending=True).head(top_n)
+    work["pair"] = (
+        work.get(COL_SENDER_ID, pd.Series(dtype="object")).fillna("sin_emisor").astype(str)
+        + "→"
+        + work.get(COL_RECEIVER_ID, pd.Series(dtype="object")).fillna("sin_receptor").astype(str)
+    )
+    plot_kwargs = {
+        "data": work,
+        "x": "feat_quid_value_vs_load_days",
+        "y": "pair",
+        "ax": axis,
+    }
+    if "feat_quid_score" in work:
+        plot_kwargs["hue"] = "feat_quid_score"
+    sns.barplot(**plot_kwargs)
+    if axis.get_legend() is not None:
+        axis.legend(title="Puntaje")
+    axis.set_title(f"Q4 – Desfase autorización/carga ({timeframe})")
+    axis.set_xlabel("Días (negativos = autorización previa)")
+    axis.set_ylabel("Par emisor → receptor")
+    return axis
+
+
+def plot_q5_reference_reuse(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica referencias de pago recurrentes."""
+    data = question5_reference_reuse(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q5 – Reutilización de referencias",
+            "Sin referencias recurrentes detectadas.",
+        )
+
+    work = data.copy()
+    if "nivel_respuesta" in work.columns:
+        work = work.loc[work["nivel_respuesta"] == "referencia"].copy()
+    if work.empty:
+        return _empty_chart(
+            axis,
+            "Q5 – Reutilización de referencias",
+            "Solo hay detalle de transacciones sin resumen por referencia.",
+        )
+
+    work = work.sort_values(["tx_count", "n_pairs"], ascending=[False, False]).head(top_n)
+    if "reference_norm" in work:
+        work["reference_norm"] = work["reference_norm"].fillna("sin_referencia").astype(str)
+    sns.barplot(data=work, x="tx_count", y="reference_norm", hue="n_pairs", ax=axis)
+    axis.set_title(f"Q5 – Referencias más reutilizadas ({timeframe})")
+    axis.set_xlabel("Número de transacciones")
+    axis.set_ylabel("Referencia normalizada")
+    axis.legend(title="Pares distintos")
+    return axis
+
+
+def plot_q6_centralizers(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica receptores con mayor centralidad."""
+    data = question6_centralizers(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q6 – Receptores centralizadores",
+            "Sin receptores centralizadores para el periodo.",
+        )
+
+    work = data.copy()
+    work = work.sort_values(["centralidad", "inflow"], ascending=[False, False]).head(top_n)
+    work[COL_RECEIVER_ID] = work[COL_RECEIVER_ID].fillna("sin_receptor").astype(str)
+    plot_kwargs = {
+        "data": work,
+        "x": "centralidad",
+        "y": COL_RECEIVER_ID,
+        "ax": axis,
+    }
+    if "month_id" in work:
+        plot_kwargs["hue"] = "month_id"
+    sns.barplot(**plot_kwargs)
+    if axis.get_legend() is not None:
+        axis.legend(title="Mes")
+    axis.set_title(f"Q6 – Receptores centralizadores ({timeframe})")
+    axis.set_xlabel("Centralidad (inflow × emisores únicos)")
+    axis.set_ylabel("Receptor")
+    return axis
+
+
+def plot_q7_net_imbalance(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica personas con mayor desbalance neto."""
+    data = question7_net_imbalance(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q7 – Desbalance neto",
+            "Sin personas con desbalance calculado.",
+        )
+
+    work = data.copy()
+    work["persona"] = work["persona"].fillna("sin_persona").astype(str)
+    work["abs_neto"] = work["desbalance_persona_monto_neto"].abs()
+    work = work.sort_values("abs_neto", ascending=False).head(top_n)
+    sns.barplot(data=work, x="desbalance_persona_monto_neto", y="persona", ax=axis)
+    axis.set_title(f"Q7 – Personas con desbalance neto ({timeframe})")
+    axis.set_xlabel("Monto neto (positivo = recibe más)")
+    axis.set_ylabel("Persona")
+    return axis
+
+
+__all__ = [
+    "plot_q1_manager_nlp",
+    "plot_q2_manager_concepts",
+    "plot_q3_quid_pairs",
+    "plot_q4_negative_value_vs_load",
+    "plot_q5_reference_reuse",
+    "plot_q6_centralizers",
+    "plot_q7_net_imbalance",
+]


### PR DESCRIPTION
## Summary
- add an `experiment_visualizations` module with seaborn charts for each experiment question (Q1–Q7)
- document quick visualization examples for every question in the README

## Testing
- python -m compileall experiment_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd7321f20832c987dc1751629e7ca