### PR TITLE
Documenta preguntas Q8-Q14 y agrega visualizaciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,153 @@ El módulo `experiment_questions.py` genera respuestas tabulares para siete preg
     plt.show()
     ```
 
+- **Q8 – Receptores nuevos con montos altos** (`question8_case13_new_employees`):
+  - **Metodología:** utiliza `reports["persona"][timeframe]` para filtrar a receptores con bandera `caso13_persona_flag_nuevo_receptor_altos_montos`. Prioriza a quienes recibieron montos altos (percentil 90) dentro de sus primeras interacciones (≤6 meses) y calcula totales, emisores únicos y promedios.
+  - **Parámetros clave:** `timeframe`.
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question8_case13_new_employees
+
+    q8 = question8_case13_new_employees(reports, timeframe="todo_el_tiempo")
+    print(q8.head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q8_case13_new_employees
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plot_q8_case13_new_employees(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q9 – Veteranos que reciben de emisores nuevos** (`question9_case14_veterans_from_newcomers`):
+  - **Metodología:** revisa `reports["persona"][timeframe]` buscando la bandera `caso14_persona_flag_antiguo_recibe_de_nuevos` o, en su defecto, reconstruye las métricas desde transacciones y heurísticas de antigüedad. Agrega transacciones y montos recibidos de emisores recientes resaltando emisores únicos y promedios.
+  - **Parámetros clave:** `timeframe`.
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question9_case14_veterans_from_newcomers
+
+    q9 = question9_case14_veterans_from_newcomers(reports, timeframe="todo_el_tiempo")
+    print(q9.head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q9_case14_veterans_from_newcomers
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q9_case14_veterans_from_newcomers(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q10 – Rachas Yo-Yo prolongadas** (`question10_yoyo_streaks`):
+  - **Metodología:** analiza `reports["transaccion"][timeframe]` con la bandera `sig_yoyo` para encontrar pares bidireccionales con rachas consecutivas de ida y vuelta. Si faltan banderas, aplica heurísticas de ventanas horarias. Cruza con el resumen `par_personas` para incorporar riesgo y filtra por rachas mínimas y riesgo máximo.
+  - **Parámetros clave:** `timeframe`; `min_consecutive` (mínimo de eventos consecutivos, por defecto `2`); `risk_threshold` (riesgo mínimo del par, por defecto `1.8`).
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question10_yoyo_streaks
+
+    q10 = question10_yoyo_streaks(reports, timeframe="ultimos_3_meses", min_consecutive=3)
+    print(q10[["par_bidir", "racha_max_yo_yo", "riesgo_max_par"]].head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q10_yoyo_streaks
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    plot_q10_yoyo_streaks(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q11 – Montos pegados a umbrales regulatorios** (`question11_near_threshold_structuring`):
+  - **Metodología:** procesa `reports["transaccion"][timeframe]` para identificar pares con bandera `sig_near_thr` y deltas pequeños (`feat_delta_near_thr`) respecto a umbrales comunes. Si falta la métrica, estima la distancia a umbrales típicos y aplica heurísticas flexibles para garantizar cobertura. Resume meses con recurrencia, monto total y riesgo.
+  - **Parámetros clave:** `timeframe`; `min_months` (meses mínimos con recurrencia, por defecto `3`); `delta_limit` (diferencia máxima al umbral, por defecto `10.0`).
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question11_near_threshold_structuring
+
+    q11 = question11_near_threshold_structuring(reports, timeframe="todo_el_tiempo", min_months=2)
+    print(q11[["pair", "meses_con_near", "monto_total_near"]].head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q11_near_threshold_structuring
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q11_near_threshold_structuring(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q12 – Smurfing crónico** (`question12_smurfing_chronic`):
+  - **Metodología:** parte de `reports["transaccion"][timeframe]` y la bandera `sig_smurf` para localizar pares con depósitos fragmentados pequeños a lo largo de varios meses. Si no hay banderas, usa cuantiles por par para etiquetar montos reducidos y estima tendencias de riesgo promedio y máximo por mes.
+  - **Parámetros clave:** `timeframe`; `min_months` (meses mínimos con smurfing, por defecto `3`).
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question12_smurfing_chronic
+
+    q12 = question12_smurfing_chronic(reports, timeframe="todo_el_tiempo", min_months=4)
+    print(q12[["pair", "meses_con_smurf", "monto_smurf_total"]].head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q12_smurfing_chronic
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q12_smurfing_chronic(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q13 – Préstamos incumplidos con ráfagas de frecuencia** (`question13_bad_loans_with_frequency`):
+  - **Metodología:** inspecciona banderas `sig_loan_bad_repay` y `sig_freq` dentro de `reports["transaccion"][timeframe]`. Calcula coincidencias mensuales de préstamos con repago ≤50% y eventos de alta frecuencia; cuando faltan banderas, emplea heurísticas bidireccionales para estimar préstamos, reembolsos y umbrales de frecuencia. Agrega meses coincidentes, montos y riesgos.
+  - **Parámetros clave:** `timeframe`; `min_months` (meses mínimos de coincidencia, por defecto `3`).
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question13_bad_loans_with_frequency
+
+    q13 = question13_bad_loans_with_frequency(reports, timeframe="todo_el_tiempo")
+    print(q13[["pair", "meses_con_coincidencia", "monto_prestamos_incumplidos"]].head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q13_bad_loans_with_frequency
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q13_bad_loans_with_frequency(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
+- **Q14 – Pagos recurrentes tipo nómina** (`question14_recurrent_payroll`):
+  - **Metodología:** utiliza `reports["transaccion"][timeframe]` y la bandera `sig_recurrent` para agrupar pagos emitidos cerca de un mismo día de corte. Identifica meses consecutivos con comportamiento recurrente y calcula totales, promedios y número de pagos, relajando banderas cuando es necesario para mantener cobertura.
+  - **Parámetros clave:** `timeframe`; `min_months` (meses consecutivos mínimos, por defecto `3`).
+  - **Ejemplo de uso:**
+    ```python
+    from experiment_questions import question14_recurrent_payroll
+
+    q14 = question14_recurrent_payroll(reports, timeframe="todo_el_tiempo", min_months=4)
+    print(q14[["emisor", "receptor", "meses_recurrentes", "monto_total"]].head())
+    ```
+  - **Visualización rápida:**
+    ```python
+    import matplotlib.pyplot as plt
+    from experiment_visualizations import plot_q14_recurrent_payroll
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+    plot_q14_recurrent_payroll(reports, timeframe="todo_el_tiempo", ax=ax)
+    plt.tight_layout()
+    plt.show()
+    ```
+
 ## CLI
 ```bash
 python -m coi_fraud --csv ./mis_transacciones.csv --out ./forensic_outputs

--- a/experiment_visualizations.py
+++ b/experiment_visualizations.py
@@ -18,6 +18,13 @@ from experiment_questions import (
     question5_reference_reuse,
     question6_centralizers,
     question7_net_imbalance,
+    question8_case13_new_employees,
+    question9_case14_veterans_from_newcomers,
+    question10_yoyo_streaks,
+    question11_near_threshold_structuring,
+    question12_smurfing_chronic,
+    question13_bad_loans_with_frequency,
+    question14_recurrent_payroll,
 )
 
 
@@ -292,6 +299,285 @@ def plot_q7_net_imbalance(
     return axis
 
 
+def plot_q8_case13_new_employees(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica receptores nuevos con montos altos recibidos."""
+    data = question8_case13_new_employees(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q8 – Receptores nuevos",
+            "Sin receptores recientes con montos altos.",
+        )
+
+    work = data.copy()
+    work["persona"] = work["persona"].fillna("sin_persona").astype(str)
+    work = work.sort_values(
+        ["caso13_persona_tx_altos", "caso13_persona_monto_total"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.barplot(
+        data=work,
+        x="caso13_persona_monto_total",
+        y="persona",
+        hue="caso13_persona_tx_altos",
+        ax=axis,
+    )
+    axis.set_title(f"Q8 – Receptores nuevos con montos altos ({timeframe})")
+    axis.set_xlabel("Monto total recibido")
+    axis.set_ylabel("Receptor")
+    axis.legend(title="Tx monto alto")
+    return axis
+
+
+def plot_q9_case14_veterans_from_newcomers(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica veteranos que reciben de emisores recientes."""
+    data = question9_case14_veterans_from_newcomers(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q9 – Veteranos desde nuevos",
+            "Sin veteranos recibiendo de emisores nuevos.",
+        )
+
+    work = data.copy()
+    work["persona"] = work["persona"].fillna("sin_persona").astype(str)
+    work = work.sort_values(
+        ["caso14_persona_tx_de_emisores_nuevos", "caso14_persona_monto_de_emisores_nuevos"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.barplot(
+        data=work,
+        x="caso14_persona_monto_de_emisores_nuevos",
+        y="persona",
+        hue="caso14_persona_emisores_nuevos_unicos",
+        ax=axis,
+    )
+    axis.set_title(f"Q9 – Veteranos receptores de nuevos ({timeframe})")
+    axis.set_xlabel("Monto recibido desde emisores nuevos")
+    axis.set_ylabel("Receptor veterano")
+    axis.legend(title="Emisores únicos")
+    return axis
+
+
+def plot_q10_yoyo_streaks(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pares con mayores rachas Yo-Yo y riesgo."""
+    data = question10_yoyo_streaks(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q10 – Rachas Yo-Yo",
+            "Sin rachas Yo-Yo identificadas.",
+        )
+
+    work = data.copy()
+    work["par_bidir"] = work["par_bidir"].fillna("sin_par").astype(str)
+    work = work.sort_values(
+        ["racha_max_yo_yo", "riesgo_max_par", "tx_yo_yo_totales"],
+        ascending=[False, False, False],
+    ).head(top_n)
+    sns.scatterplot(
+        data=work,
+        x="racha_max_yo_yo",
+        y="riesgo_max_par",
+        size="tx_yo_yo_totales",
+        hue="meses_con_yo_yo",
+        ax=axis,
+    )
+    for _, row in work.iterrows():
+        axis.text(
+            row["racha_max_yo_yo"],
+            row["riesgo_max_par"],
+            row["par_bidir"],
+            fontsize=8,
+            ha="left",
+        )
+    axis.set_title(f"Q10 – Rachas Yo-Yo ({timeframe})")
+    axis.set_xlabel("Racha máxima Yo-Yo")
+    axis.set_ylabel("Riesgo máximo del par")
+    axis.legend(title="Meses Yo-Yo", loc="best")
+    return axis
+
+
+def plot_q11_near_threshold_structuring(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pares con operaciones cerca de umbrales regulados."""
+    data = question11_near_threshold_structuring(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q11 – Cercanos a umbral",
+            "Sin montos cercanos a umbrales.",
+        )
+
+    work = data.copy()
+    work["pair"] = work["pair"].fillna("sin_par").astype(str)
+    work = work.sort_values(
+        ["meses_con_near", "monto_total_near"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.barplot(
+        data=work,
+        x="meses_con_near",
+        y="pair",
+        hue="riesgo_max",
+        ax=axis,
+    )
+    axis.set_title(f"Q11 – Montos pegados al umbral ({timeframe})")
+    axis.set_xlabel("Meses con montos cercanos")
+    axis.set_ylabel("Par emisor → receptor")
+    axis.legend(title="Riesgo máximo")
+    return axis
+
+
+def plot_q12_smurfing_chronic(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pares con patrones crónicos de smurfing."""
+    data = question12_smurfing_chronic(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q12 – Smurfing crónico",
+            "Sin pares con smurfing prolongado.",
+        )
+
+    work = data.copy()
+    work["pair"] = work["pair"].fillna("sin_par").astype(str)
+    work = work.sort_values(
+        ["meses_con_smurf", "monto_smurf_total"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.scatterplot(
+        data=work,
+        x="meses_con_smurf",
+        y="monto_smurf_total",
+        size="tx_smurf_totales",
+        hue="riesgo_max",
+        ax=axis,
+    )
+    for _, row in work.iterrows():
+        axis.text(
+            row["meses_con_smurf"],
+            row["monto_smurf_total"],
+            row["pair"],
+            fontsize=8,
+            ha="left",
+        )
+    axis.set_title(f"Q12 – Smurfing crónico ({timeframe})")
+    axis.set_xlabel("Meses con smurfing")
+    axis.set_ylabel("Monto total smurf")
+    axis.legend(title="Riesgo máximo", loc="best")
+    return axis
+
+
+def plot_q13_bad_loans_with_frequency(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pares con préstamos incobrables y alta frecuencia."""
+    data = question13_bad_loans_with_frequency(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q13 – Préstamos y frecuencia",
+            "Sin coincidencias de préstamos incobrables.",
+        )
+
+    work = data.copy()
+    work["pair"] = work["pair"].fillna("sin_par").astype(str)
+    work = work.sort_values(
+        ["meses_con_coincidencia", "monto_prestamos_incumplidos"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.barplot(
+        data=work,
+        x="monto_prestamos_incumplidos",
+        y="pair",
+        hue="eventos_alta_frecuencia",
+        ax=axis,
+    )
+    axis.set_title(f"Q13 – Préstamos incobrables frecuentes ({timeframe})")
+    axis.set_xlabel("Monto en préstamos incumplidos")
+    axis.set_ylabel("Par emisor → receptor")
+    axis.legend(title="Eventos alta frecuencia")
+    return axis
+
+
+def plot_q14_recurrent_payroll(
+    reports: dict,
+    timeframe: str = DEFAULT_TIMEFRAME,
+    *,
+    ax: Optional[Axes] = None,
+    top_n: int = 10,
+) -> Axes:
+    """Grafica pagos recurrentes tipo nómina."""
+    data = question14_recurrent_payroll(reports, timeframe)
+    axis = _ensure_axis(ax)
+    if data.empty:
+        return _empty_chart(
+            axis,
+            "Q14 – Pagos recurrentes",
+            "Sin patrones de nómina recurrente.",
+        )
+
+    work = data.copy()
+    work["emisor"] = work["emisor"].fillna("sin_emisor").astype(str)
+    work["receptor"] = work["receptor"].fillna("sin_receptor").astype(str)
+    work["pair"] = work["emisor"] + "→" + work["receptor"]
+    work = work.sort_values(
+        ["meses_recurrentes", "monto_total"],
+        ascending=[False, False],
+    ).head(top_n)
+    sns.barplot(
+        data=work,
+        x="monto_total",
+        y="pair",
+        hue="meses_recurrentes",
+        ax=axis,
+    )
+    axis.set_title(f"Q14 – Pagos recurrentes tipo nómina ({timeframe})")
+    axis.set_xlabel("Monto total pagado")
+    axis.set_ylabel("Emisor → Receptor")
+    axis.legend(title="Meses recurrentes")
+    return axis
+
+
 __all__ = [
     "plot_q1_manager_nlp",
     "plot_q2_manager_concepts",
@@ -300,4 +586,11 @@ __all__ = [
     "plot_q5_reference_reuse",
     "plot_q6_centralizers",
     "plot_q7_net_imbalance",
+    "plot_q8_case13_new_employees",
+    "plot_q9_case14_veterans_from_newcomers",
+    "plot_q10_yoyo_streaks",
+    "plot_q11_near_threshold_structuring",
+    "plot_q12_smurfing_chronic",
+    "plot_q13_bad_loans_with_frequency",
+    "plot_q14_recurrent_payroll",
 ]


### PR DESCRIPTION
## Summary
- Document the outstanding experiment questions (Q8–Q14) in the README with methodology, parameters, usage examples, and visualization snippets.
- Extend `experiment_visualizations` with plotting helpers for questions Q8–Q14 so the new documentation references executable charts.

## Testing
- python -m compileall experiment_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68dde0bbc50c832cbc71e9350938766c