### PR TITLE
Improve Colab onboarding for Google Colab usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,31 +4,70 @@
 - Instalar dependencias con `pip install -r requirements.txt` (incluye pandas, numpy, seaborn, scikit-learn y scipy; estas dos últimas son opcionales si no se entrenan embeddings)
 
 ## Instalación en Google Colab
-1. Conéctate a un cuaderno nuevo y asegúrate de estar usando un entorno con Python 3.10+.
-2. Descarga el paquete (por ejemplo, clonando el repositorio o subiendo el archivo `.zip` generado por GitHub/tu release) y descomprímelo dentro de `/content`. Un flujo típico sería:
+1. Abre un cuaderno nuevo en [Google Colab](https://colab.research.google.com/), ve a **Entorno de ejecución → Cambiar tipo de entorno de ejecución** y confirma que usas Python ≥3.10.
+2. Descarga el código directamente desde GitHub en la carpeta de trabajo de Colab (`/content`). El siguiente bloque es reproducible cada vez que necesites partir de cero:
    ```python
-   !git clone https://github.com/tu-org/coi.git /content/coi
+   %cd /content
+   !rm -rf coi  # elimina una copia previa si la hubiera
+   !git clone --depth 1 --branch main https://github.com/tu-org/coi.git coi
    %cd /content/coi
    ```
-   Si prefieres trabajar con un archivo `.zip`, basta con subirlo a Colab (o montarlo desde Drive) y ejecutar:
-   ```python
-   from zipfile import ZipFile
-
-   with ZipFile("/content/coi_fraud_mensual_viz_qa.zip", "r") as z:
-       z.extractall("/content")
-   ```
-3. Instala las dependencias mínimas:
+   > Si tienes el paquete comprimido (`.zip`), súbelo a `/content` y descomprímelo con:
+   > ```python
+   > from zipfile import ZipFile
+   >
+   > with ZipFile("/content/coi_fraud_mensual_viz_qa.zip", "r") as z:
+   >     z.extractall("/content")
+   > %cd /content/coi
+   > ```
+3. Instala las dependencias necesarias (puedes ejecutar el comando todas las veces que abras el cuaderno; pip omitirá lo que ya exista):
    ```python
    %pip install -q pandas numpy seaborn scikit-learn scipy
    ```
-4. Añade el paquete al `sys.path` si no usas instalación editable. Suponiendo que el módulo vive en `/content/coi_fraud`:
+4. Añade el repositorio al `sys.path` para que Python ubique el paquete incluso si solo lo clonaste:
    ```python
    import sys
-   sys.path.append("/content")  # o "/content/coi" si clonaste el repositorio
+   sys.path.append("/content")  # para importar coi_fraud desde /content/coi
    ```
-5. Verifica la importación con `import coi_fraud`.
+5. Valida que todo esté disponible:
+   ```python
+   import coi_fraud
+   from coi_fraud import run_pipeline
+   ```
 
-> 💡 Consejo: si montas Google Drive (`from google.colab import drive; drive.mount("/content/drive")`), puedes almacenar datasets voluminosos y leerlos directamente con `pd.read_csv("/content/drive/.../archivo.csv")`.
+> 💡 Consejo: si montas Google Drive (`from google.colab import drive; drive.mount("/content/drive")`), puedes almacenar datasets voluminosos y leerlos directamente con `pd.read_csv("/content/drive/.../archivo.csv")` sin ocupar el almacenamiento temporal de Colab.
+
+### Flujo automatizado con `colab_usage`
+Para evitar repetir pasos manuales, el repositorio incluye el módulo `colab_usage.py` pensado exclusivamente para notebooks de Colab. Usa `run_full_colab_flow` para clonar el repositorio, instalar dependencias, ejecutar el pipeline sobre tu CSV y exportar automáticamente todas las casuísticas.
+
+```python
+from colab_usage import run_full_colab_flow
+
+salidas = run_full_colab_flow(
+    csv_input_path="/content/mis_transacciones.csv",  # tu archivo con columnas mínimas
+    repo_url="https://github.com/tu-org/coi.git",
+    branch="main",
+    target_dir="/content/coi",
+    output_dir="/content/coi_casuisticas",
+    include_empty=False,  # cambia a True si quieres CSV incluso sin hallazgos
+)
+
+salidas  # muestra las rutas generadas por casuística y periodo
+```
+
+Si prefieres controlar cada paso, puedes importar helpers individuales:
+
+```python
+from colab_usage import (
+    setup_environment,
+    run_pipeline_from_csv,
+    export_casuistica_to_csv,
+)
+
+repo_path = setup_environment(force_refresh=False)
+reports = run_pipeline_from_csv("/content/mis_transacciones.csv", repo_dir=repo_path)
+export_casuistica_to_csv(reports, "/content/coi_casuisticas")
+```
 
 ## Ejemplos de uso
 ### 1. Pipeline completo con pandas
@@ -94,12 +133,9 @@ for categoria, timeframes in reports.items():
 ```
 
 ## Uso rápido (Colab)
+Una vez clonada la repo, basta con cargar tu CSV y ejecutar el pipeline:
+
 ```python
-!pip -q install pandas numpy seaborn scikit-learn scipy
-from zipfile import ZipFile
-with ZipFile("/content/coi_fraud_mensual_viz_qa.zip", "r") as z:
-    z.extractall("/content")
-import sys; sys.path.append("/content")
 import pandas as pd
 from coi_fraud import run_pipeline
 from coi_fraud.viz import plots
@@ -108,8 +144,13 @@ from coi_fraud.analysis import qa
 df = pd.read_csv("/content/mis_transacciones.csv")  # columnas mínimas: user_id, receptor-user_id, load_date, movement_amount, transaction_desc
 reports = run_pipeline(df)
 
-# gráficos
+# Exporta todas las casuísticas de manera explícita
+from colab_usage import export_casuistica_to_csv
+export_casuistica_to_csv(reports, "/content/coi_casuisticas")
+
+# gráficos y consultas
 plots.plot_person_imbalance_bar(reports)
+qa.desbalance_personas(reports).head()
 ```
 
 ### 5. Generar un dataset de prueba diverso

--- a/colab_usage.py
+++ b/colab_usage.py
@@ -1,0 +1,236 @@
+"""Utilidades específicas para ejecutar el paquete en Google Colab.
+
+Este módulo está pensado para usarse directamente desde un notebook de
+Google Colab. Incluye funciones para clonar el repositorio desde GitHub,
+instalar dependencias mínimas, añadir el paquete al ``sys.path`` y
+automatizar la generación de archivos CSV para cada casuística calculada
+por :func:`coi_fraud.run_pipeline`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+import pandas as pd
+
+try:  # pragma: no cover - solo válido en Colab con IPython
+    from IPython import get_ipython
+except ImportError:  # pragma: no cover - entorno estándar
+    get_ipython = None  # type: ignore
+
+
+DEFAULT_REPO_URL = "https://github.com/tu-org/coi.git"
+DEFAULT_BRANCH = "main"
+DEFAULT_TARGET_DIR = Path("/content/coi")
+DEFAULT_PACKAGES = ("pandas", "numpy", "seaborn", "scikit-learn", "scipy")
+CASUISTICA_PREFIX = "casuistica_"
+
+
+def _is_colab() -> bool:
+    """Detecta si el código se está ejecutando dentro de Google Colab."""
+
+    if "COLAB_GPU" in os.environ:
+        return True
+    if get_ipython is None:
+        return False
+    shell = get_ipython()
+    if not shell:
+        return False
+    return "google.colab" in str(type(shell))
+
+
+def clone_repo(
+    repo_url: str = DEFAULT_REPO_URL,
+    target_dir: Path | str = DEFAULT_TARGET_DIR,
+    branch: str = DEFAULT_BRANCH,
+    *,
+    force_refresh: bool = False,
+) -> Path:
+    """Clona el repositorio en ``target_dir`` si no existe.
+
+    Parameters
+    ----------
+    repo_url:
+        URL del repositorio GitHub.
+    target_dir:
+        Carpeta de destino dentro de ``/content``.
+    branch:
+        Rama a clonar.
+    force_refresh:
+        Si es ``True`` y la carpeta ya existe, se elimina para forzar una
+        descarga limpia.
+    """
+
+    target_path = Path(target_dir)
+    if target_path.exists():
+        if force_refresh:
+            shutil.rmtree(target_path)
+        else:
+            return target_path
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            branch,
+            repo_url,
+            str(target_path),
+        ]
+    )
+    return target_path
+
+
+def ensure_packages(packages: Iterable[str] | None = None) -> Iterable[str]:
+    """Instala los paquetes listados si no están disponibles."""
+
+    packages = tuple(packages or DEFAULT_PACKAGES)
+    missing = [pkg for pkg in packages if importlib.util.find_spec(pkg) is None]
+    if not missing:
+        return ()
+    subprocess.check_call(
+        [sys.executable, "-m", "pip", "install", "-q", *missing]
+    )
+    return missing
+
+
+def add_repo_to_path(target_dir: Path | str = DEFAULT_TARGET_DIR) -> Path:
+    """Asegura que ``target_dir`` esté en ``sys.path`` para importar ``coi_fraud``."""
+
+    path = Path(target_dir)
+    candidate = path if path.is_dir() else path.parent
+    if str(candidate) not in sys.path:
+        sys.path.append(str(candidate))
+    return candidate
+
+
+def setup_environment(
+    repo_url: str = DEFAULT_REPO_URL,
+    target_dir: Path | str = DEFAULT_TARGET_DIR,
+    branch: str = DEFAULT_BRANCH,
+    packages: Iterable[str] | None = None,
+    force_refresh: bool = False,
+) -> Path:
+    """Pipeline completo de preparación del entorno para Colab.
+
+    Devuelve la ruta al directorio donde quedó el repositorio.
+    """
+
+    if not _is_colab():
+        raise RuntimeError(
+            "Este helper está diseñado para Google Colab. Ejecuta el cuaderno "
+            "en Colab antes de usar setup_environment()."
+        )
+    repo_path = clone_repo(repo_url=repo_url, target_dir=target_dir, branch=branch, force_refresh=force_refresh)
+    ensure_packages(packages)
+    add_repo_to_path(repo_path)
+    return repo_path
+
+
+def run_pipeline_from_csv(
+    csv_path: str | os.PathLike,
+    *,
+    repo_dir: Path | str = DEFAULT_TARGET_DIR,
+) -> Mapping[str, Dict[str, pd.DataFrame]]:
+    """Carga un CSV, ejecuta ``run_pipeline`` y devuelve los reportes."""
+
+    add_repo_to_path(repo_dir)
+    from coi_fraud import run_pipeline  # import local tras asegurar sys.path
+
+    df = pd.read_csv(csv_path)
+    if df.empty:
+        raise ValueError("El archivo CSV está vacío; agrega transacciones antes de continuar.")
+    reports = run_pipeline(df)
+    if not isinstance(reports, Mapping):
+        raise TypeError("run_pipeline debería devolver un mapeo de reportes.")
+    return reports
+
+
+def export_casuistica_to_csv(
+    reports: Mapping[str, Mapping[str, pd.DataFrame]],
+    output_dir: Path | str = Path("/content/coi_casuisticas"),
+    *,
+    include_empty: bool = False,
+) -> Dict[str, Dict[str, Path]]:
+    """Genera un CSV por casuística y periodo temporal.
+
+    Parameters
+    ----------
+    reports:
+        Diccionario devuelto por :func:`run_pipeline_from_csv`.
+    output_dir:
+        Carpeta base donde se crearán subdirectorios por casuística.
+    include_empty:
+        Si es ``True``, exporta también dataframes vacíos para dejar
+        constancia de que no hubo hallazgos.
+
+    Returns
+    -------
+    dict
+        Estructura ``{casuistica: {timeframe: Path}}`` con las rutas de los
+        archivos generados.
+    """
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    generated: Dict[str, Dict[str, Path]] = {}
+    for section_name, timeframes in reports.items():
+        if not section_name.startswith(CASUISTICA_PREFIX):
+            continue
+        section_dir = output_path / section_name
+        section_dir.mkdir(exist_ok=True)
+        generated[section_name] = {}
+        for timeframe, table in timeframes.items():
+            if not isinstance(table, pd.DataFrame):
+                continue
+            if table.empty and not include_empty:
+                continue
+            filename = f"{section_name}_{timeframe}.csv"
+            file_path = section_dir / filename
+            table.to_csv(file_path, index=False)
+            generated[section_name][timeframe] = file_path
+    return generated
+
+
+def run_full_colab_flow(
+    csv_input_path: str | os.PathLike,
+    *,
+    repo_url: str = DEFAULT_REPO_URL,
+    branch: str = DEFAULT_BRANCH,
+    target_dir: Path | str = DEFAULT_TARGET_DIR,
+    output_dir: Path | str = Path("/content/coi_casuisticas"),
+    include_empty: bool = False,
+    force_refresh: bool = False,
+) -> Dict[str, Dict[str, Path]]:
+    """Ejecuta todo el flujo: clonar, instalar, correr pipeline y exportar CSV."""
+
+    repo_path = setup_environment(
+        repo_url=repo_url,
+        branch=branch,
+        target_dir=target_dir,
+        force_refresh=force_refresh,
+    )
+    reports = run_pipeline_from_csv(csv_input_path, repo_dir=repo_path)
+    return export_casuistica_to_csv(
+        reports,
+        output_dir=output_dir,
+        include_empty=include_empty,
+    )
+
+
+__all__ = [
+    "clone_repo",
+    "ensure_packages",
+    "add_repo_to_path",
+    "setup_environment",
+    "run_pipeline_from_csv",
+    "export_casuistica_to_csv",
+    "run_full_colab_flow",
+]


### PR DESCRIPTION
## Summary
- add a dedicated `colab_usage` helper module to automate cloning, dependency installation, pipeline execution, and casuística CSV exports in Google Colab
- refresh the README Colab section with precise clone/install steps and examples that leverage the new helper utilities

## Testing
- python -m compileall colab_usage.py

------
https://chatgpt.com/codex/tasks/task_e_68ddee9d0848832cba786db7f42e2aab