### PR TITLE
Handle timeframe-aware report exports

### DIFF
--- a/coi_fraud/__main__.py
+++ b/coi_fraud/__main__.py
@@ -1,6 +1,7 @@
 
 import argparse
 import pandas as pd
+
 from . import run_pipeline
 from .io.export import export_tables
 
@@ -14,8 +15,10 @@ def main():
     reports = run_pipeline(df, language="es")
     paths = export_tables(reports, args.out)
     print("\nExport listo:")
-    for k,v in paths.items():
-        print(f"  - {k}: {v}")
+    for key, path in paths.items():
+        print(f"  - {key}: {path}")
+
+    # Prueba manual rápida: python -m coi_fraud --csv <archivo.csv> --out ./exports
 
 if __name__ == "__main__":
     main()

--- a/coi_fraud/io/export.py
+++ b/coi_fraud/io/export.py
@@ -1,14 +1,32 @@
+"""Utilities for exporting pipeline tables."""
 
 import os
 from typing import Dict
+
 import pandas as pd
 
-def export_tables(reports: Dict[str, pd.DataFrame], out_dir: str) -> Dict[str, str]:
+
+def export_tables(
+    reports: Dict[str, Dict[str, pd.DataFrame]],
+    out_dir: str,
+) -> Dict[str, str]:
+    """Export pipeline reports grouped by category and timeframe."""
+
     os.makedirs(out_dir, exist_ok=True)
     ts = pd.Timestamp.utcnow().strftime("%Y%m%d_%H%M%S")
-    paths = {}
-    for name, df in reports.items():
-        p = os.path.join(out_dir, f"{name}_{ts}.csv")
-        df.to_csv(p, index=False)
-        paths[name] = p
+    paths: Dict[str, str] = {}
+
+    for category, periods in reports.items():
+        for period, table in periods.items():
+            if not isinstance(table, pd.DataFrame):
+                raise TypeError(
+                    "Expected a pandas DataFrame for report '%s/%s', got %s"
+                    % (category, period, type(table).__name__)
+                )
+
+            file_name = f"{category}_{period}_{ts}.csv"
+            path = os.path.join(out_dir, file_name)
+            table.to_csv(path, index=False)
+            paths[f"{category}/{period}"] = path
+
     return paths


### PR DESCRIPTION
## Summary
- update export_tables to handle nested category/timeframe reports and validate DataFrame inputs
- adjust CLI printer to reflect new flat key format and add quick manual check hint

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf194bb24832ca17aa8d50597b03d