### PR TITLE
Adjust synthetic dataset size to 6k records

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ interpretabilidad[["question_id", "filas", "interpretabilidad_ejemplos"]].head()
 ```python
 from coi_fraud import generate_diverse_dataset
 
-dataset = generate_diverse_dataset()  # 10 000 filas por defecto
+dataset = generate_diverse_dataset()  # 6 000 filas por defecto
 ```
 
 ## Preguntas de experimentación (Q1–Q7)

--- a/coi_fraud/utils/synthetic_data.py
+++ b/coi_fraud/utils/synthetic_data.py
@@ -476,13 +476,13 @@ def _build_behavioral_case(rng: np.random.Generator) -> dict:
     }
 
 
-def generate_diverse_dataset(n_records: int = 10_000, seed: int | None = 42) -> pd.DataFrame:
-    """Create a synthetic dataframe with 10k highly diverse transactions.
+def generate_diverse_dataset(n_records: int = 6_000, seed: int | None = 42) -> pd.DataFrame:
+    """Create a synthetic dataframe with 6k highly diverse transactions.
 
     Parameters
     ----------
     n_records:
-        Número de transacciones a generar. Por defecto 10 000.
+        Número de transacciones a generar. Por defecto 6 000.
     seed:
         Semilla opcional para obtener resultados reproducibles.
 
@@ -496,7 +496,8 @@ def generate_diverse_dataset(n_records: int = 10_000, seed: int | None = 42) -> 
         raise ValueError("n_records debe ser mayor a 0")
 
     rng = np.random.default_rng(seed)
-    personas = _build_personas(rng, size=max(320, n_records // 20))
+    persona_pool = max(240, max(1, n_records // 24))
+    personas = _build_personas(rng, size=persona_pool)
     persona_ids = [p.user_id for p in personas]
 
     start = datetime(2020, 1, 1)

--- a/experiment.py
+++ b/experiment.py
@@ -28,8 +28,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--rows",
         type=int,
-        default=5_000,
-        help="Número de transacciones a generar (por defecto: 5000).",
+        default=6_000,
+        help="Número de transacciones a generar (por defecto: 6000).",
     )
     parser.add_argument(
         "--seed",

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -97,8 +97,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--rows",
         type=int,
-        default=10_000,
-        help="Filas a generar cuando se use el dataset sintético (por defecto: 10000).",
+        default=6_000,
+        help="Filas a generar cuando se use el dataset sintético (por defecto: 6000).",
     )
     parser.add_argument(
         "--seed",


### PR DESCRIPTION
## Summary
- reduce the default synthetic dataset to 6,000 transactions and decrease the persona pool to yield slightly fewer users
- update the experiment CLIs and README to reference the new dataset size

## Testing
- python -m compileall coi_fraud

------
https://chatgpt.com/codex/tasks/task_e_68ddffe35468832cb0a6833898f56355