### PR TITLE
Preserve NLP source text across aggregate tables

### DIFF
--- a/coi_fraud/aggregate/clusters.py
+++ b/coi_fraud/aggregate/clusters.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, List, Set
 
 import pandas as pd
 
-from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+from ..schemas import COL_AMOUNT, COL_DESCRIPTION, COL_RECEIVER_ID, COL_SENDER_ID
 
 
 def _build_components(edges: Iterable[tuple]) -> List[Set]:
@@ -38,16 +38,34 @@ def _build_components(edges: Iterable[tuple]) -> List[Set]:
     return components
 
 
-def _top_concepts(df: pd.DataFrame) -> List[str]:
-    if df.empty:
+def _collect_texts(series: pd.Series) -> List[str]:
+    if series is None or series.empty:
         return []
+    texts = series.astype("string").fillna("").str.strip()
+    return [text for text in texts.tolist() if text]
+
+
+def _top_concepts(df: pd.DataFrame) -> tuple[List[str], List[List[str]]]:
+    if df.empty:
+        return [], []
+    work = df.copy()
+    text_series = work.get(COL_DESCRIPTION)
+    if text_series is None:
+        text_series = pd.Series("", index=work.index, dtype="string")
+    else:
+        text_series = text_series.astype("string").fillna("").str.strip()
+    work["_nlp_texto_original"] = text_series
     counts = (
-        df.groupby("nlp_concepto_sospechoso", observed=True)[COL_AMOUNT]
-        .count()
-        .reset_index(name="cnt")
+        work.groupby("nlp_concepto_sospechoso", observed=True)
+        .agg(
+            cnt=(COL_AMOUNT, "count"),
+            textos=("_nlp_texto_original", _collect_texts),
+        )
+        .reset_index()
         .sort_values(["cnt", "nlp_concepto_sospechoso"], ascending=[False, True])
     )
-    return counts["nlp_concepto_sospechoso"].head(3).tolist()
+    top = counts.head(3)
+    return top["nlp_concepto_sospechoso"].tolist(), top["textos"].tolist()
 
 
 def build_person_clusters(df: pd.DataFrame) -> pd.DataFrame:
@@ -64,6 +82,7 @@ def build_person_clusters(df: pd.DataFrame) -> pd.DataFrame:
                 "nlp_cluster_total_transacciones_sospechosas",
                 "nlp_cluster_conceptos_sospechosos_unicos",
                 "nlp_cluster_top_conceptos",
+                "nlp_cluster_top_textos",
                 "yo_yo_cluster_tasa_flag",
                 "smurf_cluster_tasa_flag",
                 "frecuencia_cluster_tasa_flag",
@@ -112,6 +131,8 @@ def build_person_clusters(df: pd.DataFrame) -> pd.DataFrame:
         riesgo_avg = cluster_df["risk_score"].mean()
         riesgo_max = float(riesgo_max) if pd.notna(riesgo_max) else 0.0
         riesgo_avg = float(riesgo_avg) if pd.notna(riesgo_avg) else 0.0
+        top_concepts, top_texts = _top_concepts(suspicious_df)
+
         record = {
             "cluster_id": f"cluster_{idx}",
             "cluster_personas": sorted(comp),
@@ -124,7 +145,8 @@ def build_person_clusters(df: pd.DataFrame) -> pd.DataFrame:
             "nlp_cluster_conceptos_sospechosos_unicos": int(
                 suspicious_df["nlp_concepto_sospechoso"].nunique()
             ),
-            "nlp_cluster_top_conceptos": _top_concepts(suspicious_df),
+            "nlp_cluster_top_conceptos": top_concepts,
+            "nlp_cluster_top_textos": top_texts,
             "yo_yo_cluster_tasa_flag": float(cluster_df["sig_yoyo"].fillna(0.0).mean()),
             "smurf_cluster_tasa_flag": float(cluster_df["sig_smurf"].fillna(0.0).mean()),
             "frecuencia_cluster_tasa_flag": float(cluster_df["sig_freq"].fillna(0.0).mean()),

--- a/coi_fraud/aggregate/concepts.py
+++ b/coi_fraud/aggregate/concepts.py
@@ -1,6 +1,17 @@
 import pandas as pd
 
-from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_SENDER_ID
+from ..schemas import COL_AMOUNT, COL_DESCRIPTION, COL_RECEIVER_ID, COL_SENDER_ID
+
+
+def _collect_texts(series: pd.Series) -> list[str]:
+    if series is None or series.empty:
+        return []
+    texts = (
+        series.astype("string")
+        .fillna("")
+        .str.strip()
+    )
+    return [text for text in texts.tolist() if text]
 
 
 def _suspicious_concepts(df: pd.DataFrame) -> pd.DataFrame:
@@ -30,6 +41,7 @@ def build_concept_tables(df: pd.DataFrame):
                 "nlp_concepto_receptores_unicos",
                 "nlp_concepto_riesgo_promedio",
                 "nlp_concepto_riesgo_p95",
+                "nlp_concepto_textos_originales",
             ]
         )
         persona = pd.DataFrame(
@@ -39,6 +51,7 @@ def build_concept_tables(df: pd.DataFrame):
                 "nlp_persona_concepto_tx_total",
                 "nlp_persona_concepto_monto_total",
                 "nlp_persona_concepto_riesgo_promedio",
+                "nlp_persona_concepto_textos",
             ]
         )
         par = pd.DataFrame(
@@ -48,9 +61,19 @@ def build_concept_tables(df: pd.DataFrame):
                 "nlp_par_concepto_tx_total",
                 "nlp_par_concepto_monto_total",
                 "nlp_par_concepto_riesgo_promedio",
+                "nlp_par_concepto_textos",
             ]
         )
         return conceptos, persona, par
+
+    text_series = df.get(COL_DESCRIPTION)
+    if text_series is None:
+        text_series = pd.Series("", index=df.index, dtype="string")
+    else:
+        text_series = text_series.astype("string").fillna("").str.strip()
+
+    txc = txc.copy()
+    txc["_nlp_texto_original"] = text_series.loc[txc.index]
 
     agg_concepto = (
         txc.groupby("nlp_concepto_sospechoso", observed=True)
@@ -63,6 +86,10 @@ def build_concept_tables(df: pd.DataFrame):
             nlp_concepto_riesgo_p95=(
                 "risk_score",
                 lambda s: float(s.quantile(0.95)) if len(s) else 0.0,
+            ),
+            nlp_concepto_textos_originales=(
+                "_nlp_texto_original",
+                _collect_texts,
             ),
         )
         .reset_index()
@@ -78,6 +105,10 @@ def build_concept_tables(df: pd.DataFrame):
             nlp_persona_concepto_tx_total=(COL_AMOUNT, "count"),
             nlp_persona_concepto_monto_total=(COL_AMOUNT, "sum"),
             nlp_persona_concepto_riesgo_promedio=("risk_score", "mean"),
+            nlp_persona_concepto_textos=(
+                "_nlp_texto_original",
+                _collect_texts,
+            ),
         )
         .reset_index()
         .rename(columns={COL_SENDER_ID: "persona"})
@@ -90,6 +121,10 @@ def build_concept_tables(df: pd.DataFrame):
             nlp_par_concepto_tx_total=(COL_AMOUNT, "count"),
             nlp_par_concepto_monto_total=(COL_AMOUNT, "sum"),
             nlp_par_concepto_riesgo_promedio=("risk_score", "mean"),
+            nlp_par_concepto_textos=(
+                "_nlp_texto_original",
+                _collect_texts,
+            ),
         )
         .reset_index()
     )

--- a/coi_fraud/aggregate/pairs.py
+++ b/coi_fraud/aggregate/pairs.py
@@ -1,11 +1,24 @@
 import pandas as pd
 
 from ..interpret.pair import pair_interpretation
-from ..schemas import COL_AMOUNT, COL_RECEIVER_ID, COL_RELATION, COL_SENDER_ID
+from ..schemas import (
+    COL_AMOUNT,
+    COL_DESCRIPTION,
+    COL_RECEIVER_ID,
+    COL_RELATION,
+    COL_SENDER_ID,
+)
 
 
 CASE12_MIN_TX = 3
 CASE12_OFUSCATED_TOL_RATIO = 0.03
+
+
+def _collect_texts(series: pd.Series) -> list[str]:
+    if series is None or series.empty:
+        return []
+    texts = series.astype("string").fillna("").str.strip()
+    return [text for text in texts.tolist() if text]
 
 
 def _compute_case12_tandas(df: pd.DataFrame) -> pd.DataFrame:
@@ -95,6 +108,7 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
                 "nlp_par_total_transacciones_sospechosas",
                 "nlp_par_conceptos_sospechosos_unicos",
                 "nlp_par_top_conceptos",
+                "nlp_par_top_textos",
             ]
         )
 
@@ -122,9 +136,17 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
         .reset_index()
     )
 
-    suspicious_mask = tmp.get("nlp_concepto_sospechoso").fillna("").astype("string").str.strip() != ""
+    suspicious_mask = (
+        tmp.get("nlp_concepto_sospechoso").fillna("").astype("string").str.strip() != ""
+    )
     tmp_suspicious = tmp.loc[suspicious_mask].copy()
     if not tmp_suspicious.empty:
+        text_series = tmp_suspicious.get(COL_DESCRIPTION)
+        if text_series is None:
+            text_series = pd.Series("", index=tmp_suspicious.index, dtype="string")
+        else:
+            text_series = text_series.astype("string").fillna("").str.strip()
+        tmp_suspicious["_nlp_texto_original"] = text_series
         concept_counts = (
             tmp_suspicious.groupby("pair", observed=True)["nlp_concepto_sospechoso"]
             .agg(
@@ -134,9 +156,14 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
             .reset_index()
         )
         topc = (
-            tmp_suspicious.groupby(["pair", "nlp_concepto_sospechoso"], observed=True)[COL_AMOUNT]
-            .count()
-            .reset_index(name="cnt")
+            tmp_suspicious.groupby(
+                ["pair", "nlp_concepto_sospechoso"], observed=True
+            )
+            .agg(
+                cnt=(COL_AMOUNT, "count"),
+                textos=("_nlp_texto_original", _collect_texts),
+            )
+            .reset_index()
         )
         topc = (
             topc.sort_values(["pair", "cnt"], ascending=[True, False])
@@ -144,7 +171,11 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
             .head(3)
         )
         tops = (
-            topc.groupby("pair")["nlp_concepto_sospechoso"].apply(list).rename("nlp_par_top_conceptos")
+            topc.groupby("pair")
+            .agg(
+                nlp_par_top_conceptos=("nlp_concepto_sospechoso", list),
+                nlp_par_top_textos=("textos", list),
+            )
         )
         agg = agg.merge(concept_counts, on="pair", how="left")
         agg = agg.merge(tops, on="pair", how="left")
@@ -152,6 +183,7 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
         agg["nlp_par_total_transacciones_sospechosas"] = 0
         agg["nlp_par_conceptos_sospechosos_unicos"] = 0
         agg["nlp_par_top_conceptos"] = [[] for _ in range(len(agg))]
+        agg["nlp_par_top_textos"] = [[] for _ in range(len(agg))]
 
     for col in [
         "nlp_par_total_transacciones_sospechosas",
@@ -165,6 +197,12 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
         agg["nlp_par_top_conceptos"] = [[] for _ in range(len(agg))]
     else:
         agg["nlp_par_top_conceptos"] = agg["nlp_par_top_conceptos"].apply(
+            lambda x: x if isinstance(x, list) else []
+        )
+    if "nlp_par_top_textos" not in agg:
+        agg["nlp_par_top_textos"] = [[] for _ in range(len(agg))]
+    else:
+        agg["nlp_par_top_textos"] = agg["nlp_par_top_textos"].apply(
             lambda x: x if isinstance(x, list) else []
         )
 
@@ -184,4 +222,5 @@ def build_pair_monthly(df: pd.DataFrame) -> pd.DataFrame:
     agg["interp_pair"] = agg.apply(pair_interpretation, axis=1)
     agg = agg.sort_values(["risk_max", "tx_sum"], ascending=[False, False])
     agg["top_conceptos"] = agg["nlp_par_top_conceptos"]
+    agg["top_textos"] = agg["nlp_par_top_textos"]
     return agg

--- a/coi_fraud/aggregate/persons.py
+++ b/coi_fraud/aggregate/persons.py
@@ -3,6 +3,7 @@ import pandas as pd
 from ..interpret.person import person_interpretation
 from ..schemas import (
     COL_AMOUNT,
+    COL_DESCRIPTION,
     COL_RECEIVER_ID,
     COL_RECEIVER_TENURE_YEARS,
     COL_SENDER_ID,
@@ -21,6 +22,13 @@ CASE14_MIN_UNIQUE_SENDERS = 3
 
 def _ensure_string(series: pd.Series) -> pd.Series:
     return series.fillna("").astype("string").str.strip()
+
+
+def _collect_texts(series: pd.Series) -> list[str]:
+    if series is None or series.empty:
+        return []
+    texts = series.astype("string").fillna("").str.strip()
+    return [text for text in texts.tolist() if text]
 
 
 def _safe_zscore(series: pd.Series) -> pd.Series:
@@ -280,8 +288,14 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
     people["risk_avg_person"] = (people["risk_avg_em"] + people["risk_avg_re"]) / 2.0
 
     concept_series = _ensure_string(df.get("nlp_concepto_sospechoso", ""))
+    text_series = df.get(COL_DESCRIPTION)
+    if text_series is None:
+        text_series = pd.Series("", index=df.index, dtype="string")
+    else:
+        text_series = text_series.astype("string").fillna("").str.strip()
     df_concepts = df.loc[concept_series != ""].copy()
     df_concepts["nlp_concepto_sospechoso"] = concept_series.loc[df_concepts.index]
+    df_concepts["_nlp_texto_original"] = text_series.loc[df_concepts.index]
 
     if not df_concepts.empty:
         suspicious_counts = (
@@ -294,11 +308,14 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
             .rename(columns={COL_SENDER_ID: "persona"})
         )
         topc = (
-            df_concepts.groupby([COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True)[
-                COL_AMOUNT
-            ]
-            .count()
-            .reset_index(name="cnt")
+            df_concepts.groupby(
+                [COL_SENDER_ID, "nlp_concepto_sospechoso"], observed=True
+            )
+            .agg(
+                cnt=(COL_AMOUNT, "count"),
+                textos=("_nlp_texto_original", _collect_texts),
+            )
+            .reset_index()
         )
         topc = (
             topc.sort_values([COL_SENDER_ID, "cnt"], ascending=[True, False])
@@ -306,9 +323,11 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
             .head(3)
         )
         tops = (
-            topc.groupby(COL_SENDER_ID)["nlp_concepto_sospechoso"]
-            .apply(list)
-            .rename("nlp_persona_top_conceptos")
+            topc.groupby(COL_SENDER_ID)
+            .agg(
+                nlp_persona_top_conceptos=("nlp_concepto_sospechoso", list),
+                nlp_persona_top_textos=("textos", list),
+            )
             .reset_index()
             .rename(columns={COL_SENDER_ID: "persona"})
         )
@@ -318,6 +337,7 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
         people["nlp_persona_total_transacciones_sospechosas"] = 0
         people["nlp_persona_conceptos_sospechosos_unicos"] = 0
         people["nlp_persona_top_conceptos"] = [[] for _ in range(len(people))]
+        people["nlp_persona_top_textos"] = [[] for _ in range(len(people))]
 
     for col in [
         "nlp_persona_total_transacciones_sospechosas",
@@ -331,6 +351,12 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
         people["nlp_persona_top_conceptos"] = [[] for _ in range(len(people))]
     else:
         people["nlp_persona_top_conceptos"] = people["nlp_persona_top_conceptos"].apply(
+            lambda x: x if isinstance(x, list) else ([] if pd.isna(x) else [x])
+        )
+    if "nlp_persona_top_textos" not in people:
+        people["nlp_persona_top_textos"] = [[] for _ in range(len(people))]
+    else:
+        people["nlp_persona_top_textos"] = people["nlp_persona_top_textos"].apply(
             lambda x: x if isinstance(x, list) else ([] if pd.isna(x) else [x])
         )
 
@@ -624,6 +650,13 @@ def build_person_monthly(df: pd.DataFrame) -> pd.DataFrame:
     else:
         people["top_conceptos"] = [[] for _ in range(len(people))]
     people["top_conceptos"] = people["top_conceptos"].apply(lambda x: x if isinstance(x, list) else [])
+    if "nlp_persona_top_textos" in people:
+        people["top_textos"] = people["nlp_persona_top_textos"]
+    else:
+        people["top_textos"] = [[] for _ in range(len(people))]
+    people["top_textos"] = people["top_textos"].apply(
+        lambda x: x if isinstance(x, list) else []
+    )
     people["interp_person"] = people.apply(person_interpretation, axis=1)
     return people.sort_values(
         ["risk_avg_person", "sum_emit", "sum_recv"], ascending=[False, False, False]


### PR DESCRIPTION
## Summary
- capture original transaction text when building concept, person, pair, and cluster NLP aggregates
- expose text collections alongside existing top concept columns so downstream data frames retain the underlying language

## Testing
- python -m compileall coi_fraud

------
https://chatgpt.com/codex/tasks/task_e_68dec0e88e70832c97aa44fbc7a1ec05