### PR TITLE
Expand MX NLP with embedding-based synonym discovery

### DIFF
--- a/coi_fraud/features/nlp_mx.py
+++ b/coi_fraud/features/nlp_mx.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
 from ..schemas import COL_DESCRIPTION, COL_RELATION
+from ..text_utils import clean_raw_concept, first_non_empty_series
 from .nlp_mx_impl import nlp_mx_etiquetar_transacciones_pro
 
 
@@ -19,4 +20,18 @@ def apply_nlp(df: pd.DataFrame) -> pd.DataFrame:
     df2["feat_nlp_sentimiento"] = out["sentimiento"]
     df2["feat_nlp_coi_score"] = out["score_probable_coi"]
     df2["nlp_evento_corporativo"] = out["evento_corporativo"]
+    concept_source = first_non_empty_series(
+        df2,
+        [
+            "nlp_concepto_crudo",
+            "reference_number_trans_desc",
+            COL_DESCRIPTION,
+            "tx_tags",
+            "feat_reference_norm",
+            "nlp_concepto_sospechoso",
+        ],
+    )
+    if concept_source.empty and not df2.empty:
+        concept_source = pd.Series([""] * len(df2), index=df2.index, dtype="string")
+    df2["nlp_concepto_crudo"] = concept_source.reindex(df2.index, fill_value="").map(clean_raw_concept)
     return df2

--- a/coi_fraud/features/nlp_mx_impl.py
+++ b/coi_fraud/features/nlp_mx_impl.py
@@ -122,6 +122,7 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "aportación",
                 "cooperacion",
                 "cooperación",
+                "coperacion",
                 "alinearse",
                 "afloja",
                 "no te cierres",
@@ -421,8 +422,8 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "operacion oculta verde",
             ],
         },
-        "DEIXIS": {
-            "peso": 1.1,
+        "COORDINACION_REITERADA": {
+            "peso": 1.2,
             "palabras": [
                 "lo de ayer",
                 "lo de antier",
@@ -430,20 +431,42 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "como quedamos",
                 "igual que ayer",
                 "igual que antes",
-                "ya sabes",
-                "aquello",
-                "eso",
-                "lo pendiente",
                 "igual trato",
                 "lo de siempre",
                 "lo acostumbrado",
                 "misma jugada",
+                "mismo trato",
+                "lo pendiente de ayer",
             ],
-            "patrones": [],
+            "patrones": [
+                r"lo\s+de\s+(ayer|siempre|antes)",
+                r"(misma|mismo)\s+(jugada|trato)",
+            ],
             "seeds": [
                 "lo de ayer igual",
                 "como quedamos",
                 "misma jugada de siempre",
+            ],
+        },
+        "ALUSION_INDIRECTA": {
+            "peso": 1.0,
+            "palabras": [
+                "ya sabes",
+                "aquello",
+                "eso",
+                "lo pendiente",
+                "lo conversado",
+                "ya quedamos",
+                "lo hablado",
+                "el tema",
+            ],
+            "patrones": [
+                r"ya\s+sabes",
+                r"lo\s+pendiente",
+            ],
+            "seeds": [
+                "ya sabes que hacer",
+                "lo pendiente queda igual",
             ],
         },
         "EMOCIONAL": {
@@ -466,6 +489,9 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "idolo",
                 "heroina",
                 "heroína",
+                "gracias por tanto",
+                "gracias totales",
+                "agradezco mucho",
             ],
             "patrones": [],
             "seeds": [
@@ -497,6 +523,12 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "after office privado",
                 "cena romantica",
                 "vino en suite",
+                "tanga",
+                "tangas",
+                "lenceria",
+                "lencería",
+                "tus tangas",
+                "elefant",
             ],
             "patrones": [
                 r"(favor|salida|cita|encuentro).{0,10}(intim|privad|personal)",
@@ -511,6 +543,63 @@ def nlp_mx_etiquetar_transacciones_pro(
                 "cita privada para liberar la orden",
                 "trato especial por el contrato",
                 "noche juntos por adjudicacion",
+            ],
+        },
+        "AGASAJOS_SOCIALES": {
+            "peso": 2.0,
+            "palabras": [
+                "cerveza",
+                "chela",
+                "chelas",
+                "tragos",
+                "pomo",
+                "after",
+                "aftercito",
+                "fiesta",
+                "fiestecita",
+                "antro",
+                "karaoke",
+                "botella",
+                "tequila",
+                "mezcal",
+                "brindis",
+                "cena bar",
+                "tapas",
+            ],
+            "patrones": [
+                r"(after|fiesta|antro|karaoke)",
+                r"(botella|pomo|tragos?).{0,10}(vip|premium)?",
+            ],
+            "seeds": [
+                "fiesta con pomos para celebrar aprobacion",
+                "chelas despues de liberar contrato",
+                "after en el antro por la firma",
+            ],
+        },
+        "DETALLE_PERSONAL": {
+            "peso": 2.2,
+            "palabras": [
+                "regalo",
+                "regalito",
+                "detallito",
+                "detallazo",
+                "detallito especial",
+                "detalle personal",
+                "detalle para ti",
+                "te compras algo bonito",
+                "tecomprasalgobonito",
+                "tecomprasalgobonit",
+                "te compras algo bonit",
+                "reglo",
+            ],
+            "patrones": [
+                r"te\s*compras?\s*algo\s*bonit",
+                r"regal(?:o|ito)",
+            ],
+            "seeds": [
+                "te compras algo bonito por el apoyo",
+                "regalito especial por liberar contrato",
+                "detalle personal por tu ayuda",
             ],
         },
         "REGALOS_LUJO": {
@@ -717,14 +806,22 @@ def nlp_mx_etiquetar_transacciones_pro(
         "regalo despedida",
     }
 
+    raw_series = df[col_texto].fillna("").astype(str)
+    norm_series = raw_series.apply(norm_basic)
+    toks_series = norm_series.apply(tokens)
+
     vectorizer = None
     cat_centroids = {}
+    cat_centroids_matrix = None
+    fams_for_similarity: list[str] = []
+    embedding_expanded_terms: dict[str, set[str]] = {fam: set() for fam in LEX}
     if use_embeddings:
         try:
             from sklearn.feature_extraction.text import TfidfVectorizer
 
-            docs: list[str] = []
+            lexical_docs: list[str] = []
             y: list[str] = []
+            base_terms_per_fam: dict[str, set[str]] = {fam: set() for fam in LEX}
             augmentation_contexts = [
                 "licitacion urgente",
                 "proveedor favorito",
@@ -742,37 +839,97 @@ def nlp_mx_etiquetar_transacciones_pro(
                 for s in spec.get("seeds", []):
                     base = norm_basic(s)
                     if base and base not in seen_terms:
-                        docs.append(base)
+                        lexical_docs.append(base)
                         y.append(fam)
                         seen_terms.add(base)
+                        base_terms_per_fam[fam].add(base)
                     for ctx in augmentation_contexts:
                         combo = norm_basic(f"{s} {ctx}")
                         if combo and combo not in seen_terms:
-                            docs.append(combo)
+                            lexical_docs.append(combo)
                             y.append(fam)
                             seen_terms.add(combo)
                 for w in spec.get("palabras", []):
                     base = norm_basic(w)
                     if base and base not in seen_terms:
-                        docs.append(base)
+                        lexical_docs.append(base)
                         y.append(fam)
                         seen_terms.add(base)
+                        base_terms_per_fam[fam].add(base)
                     if " " not in w:
                         doubled = norm_basic(f"{w} urgente")
                         if doubled and doubled not in seen_terms:
-                            docs.append(doubled)
+                            lexical_docs.append(doubled)
                             y.append(fam)
                             seen_terms.add(doubled)
             vectorizer = TfidfVectorizer(analyzer="char", ngram_range=(3, 5), min_df=1)
-            X = vectorizer.fit_transform(docs)
+            extra_docs: list[str] = []
+            seen_extra: set[str] = set()
+            unique_norm_texts = list(dict.fromkeys(norm_series.tolist()))
+            for text in unique_norm_texts:
+                if not text or text in seen_extra:
+                    continue
+                extra_docs.append(text)
+                seen_extra.add(text)
+                if len(extra_docs) >= 4000:
+                    break
+            fit_corpus = lexical_docs + extra_docs
+            if not fit_corpus:
+                raise ValueError("No hay corpus para inicializar embeddings.")
+            vectorizer.fit(fit_corpus)
+            X = vectorizer.transform(lexical_docs)
             fam_to: dict[str, list] = {}
             for fam, row in zip(y, X):
                 fam_to.setdefault(fam, []).append(row)
             for fam, mats in fam_to.items():
                 cat_centroids[fam] = mats[0] if len(mats) == 1 else sum(mats) / len(mats)
+            if cat_centroids:
+                from scipy.sparse import vstack
+
+                fams_for_similarity = list(cat_centroids.keys())
+                cat_centroids_matrix = vstack([cat_centroids[f] for f in fams_for_similarity])
+
+                candidate_segments: list[str] = []
+                seen_segments: set[str] = set()
+                MAX_SEGMENTS = 12000
+                for text in unique_norm_texts:
+                    if len(candidate_segments) >= MAX_SEGMENTS:
+                        break
+                    words = [w for w in text.split() if len(w) >= 3]
+                    if not words:
+                        continue
+                    for size in (1, 2, 3):
+                        if len(words) < size:
+                            continue
+                        for idx in range(len(words) - size + 1):
+                            segment = " ".join(words[idx : idx + size])
+                            if len(segment) < 4 or segment in seen_segments:
+                                continue
+                            seen_segments.add(segment)
+                            candidate_segments.append(segment)
+                            if len(candidate_segments) >= MAX_SEGMENTS:
+                                break
+                        if len(candidate_segments) >= MAX_SEGMENTS:
+                            break
+                if candidate_segments:
+                    from sklearn.metrics.pairwise import cosine_similarity
+
+                    X_candidates = vectorizer.transform(candidate_segments)
+                    if X_candidates.nnz:
+                        sims_segments = cosine_similarity(X_candidates, cat_centroids_matrix)
+                        for seg_idx, sims_row in enumerate(sims_segments):
+                            for fam_idx, sim in enumerate(sims_row):
+                                if sim >= 0.32:
+                                    fam = fams_for_similarity[fam_idx]
+                                    seg = candidate_segments[seg_idx]
+                                    if seg not in base_terms_per_fam[fam]:
+                                        embedding_expanded_terms[fam].add(seg)
         except Exception:
             vectorizer = None
             cat_centroids = {}
+            cat_centroids_matrix = None
+            fams_for_similarity = []
+            embedding_expanded_terms = {fam: set() for fam in LEX}
 
     def vaguedad(tokens_list):
         VAG_TERMS = {
@@ -884,6 +1041,7 @@ def nlp_mx_etiquetar_transacciones_pro(
         social_hit = any(w in norm_text for w in SOCIAL_WHITELIST)
         for fam, spec in LEX.items():
             fam_hits = []
+            embed_bonus = 0.0
             for w in spec.get("palabras", []):
                 nw = norm_basic(w)
                 if " " in nw:
@@ -894,6 +1052,13 @@ def nlp_mx_etiquetar_transacciones_pro(
                         fam_hits.append(w)
                     elif fuzzy_contains(norm_text, nw, 0.9):
                         fam_hits.append(w)
+            emb_hits = []
+            for emb in embedding_expanded_terms.get(fam, ()):  # términos sugeridos por embeddings
+                if emb in norm_text or fuzzy_contains(norm_text, emb, 0.92):
+                    emb_hits.append(emb)
+            if emb_hits:
+                fam_hits.extend(f"emb:{emb}" for emb in emb_hits)
+                embed_bonus = spec["peso"] * (0.45 if len(emb_hits) == 1 else 0.7)
             for pat in spec.get("patrones", []):
                 try:
                     rx = re.compile(pat)
@@ -907,7 +1072,7 @@ def nlp_mx_etiquetar_transacciones_pro(
             if fam_hits:
                 categorias.append(fam)
                 frases.extend(fam_hits)
-                contrib[fam] = contrib.get(fam, 0.0) + spec["peso"]
+                contrib[fam] = contrib.get(fam, 0.0) + spec["peso"] + embed_bonus
         if "OFUSCACION" in contrib and evento_presente:
             contrib["OFUSCACION"] += 1.2
             frases.append("ofuscacion+evento")
@@ -925,25 +1090,17 @@ def nlp_mx_etiquetar_transacciones_pro(
             return "MEDIO"
         return "BAJO"
 
-    raw_series = df[col_texto].fillna("")
-    norm_series = raw_series.apply(norm_basic)
-    toks_series = norm_series.apply(tokens)
-
     sims_per_row = [None] * len(df)
-    if vectorizer is not None:
+    if vectorizer is not None and cat_centroids_matrix is not None and fams_for_similarity:
         from sklearn.metrics.pairwise import cosine_similarity
-        from scipy.sparse import vstack
 
         Xq = vectorizer.transform(norm_series.tolist())
-        fams = list(cat_centroids.keys())
-        if fams:
-            C = vstack([cat_centroids[f] for f in fams])
-            S = cosine_similarity(Xq, C)
-            for i in range(len(df)):
-                row = {fams[j]: float(S[i, j]) for j in range(len(fams))}
-                sims_per_row[i] = dict(
-                    sorted(row.items(), key=lambda kv: kv[1], reverse=True)[:return_similitudes_top]
-                )
+        S = cosine_similarity(Xq, cat_centroids_matrix)
+        for i in range(len(df)):
+            row = {fams_for_similarity[j]: float(S[i, j]) for j in range(len(fams_for_similarity))}
+            sims_per_row[i] = dict(
+                sorted(row.items(), key=lambda kv: kv[1], reverse=True)[:return_similitudes_top]
+            )
 
     conceptos = []
     niveles = []
@@ -991,9 +1148,9 @@ def nlp_mx_etiquetar_transacciones_pro(
         if emo > 0:
             score += 0.3
             frases.append("emoji")
-        if "DEIXIS" in cats and len(cats) > 1:
+        if any(c in {"COORDINACION_REITERADA", "ALUSION_INDIRECTA"} for c in cats) and len(cats) > 1:
             score += 0.6
-            frases.append("deixis+otra")
+            frases.append("coordinacion_vaga")
         if has_rel:
             r = str(df[col_relacion].iat[i]).lower()
             if "manager" in r and any(
@@ -1009,6 +1166,8 @@ def nlp_mx_etiquetar_transacciones_pro(
                     "COI_RELACIONAL",
                     "FAVORES_SEXUALES",
                     "REGALOS_LUJO",
+                    "AGASAJOS_SOCIALES",
+                    "DETALLE_PERSONAL",
                     "CONFLICTO_INTERES_FAMILIAR",
                     "FACTURACION_SIMULADA",
                     "CONSULTORIA_FANTASMA",
@@ -1034,7 +1193,10 @@ def nlp_mx_etiquetar_transacciones_pro(
             sims_all.append(sims_per_row[i])
         else:
             sims_all.append({})
-        if cats and all(c in {"DINERO_SLANG", "EMOCIONAL", "DEIXIS"} for c in cats):
+        if cats and all(
+            c in {"DINERO_SLANG", "EMOCIONAL", "COORDINACION_REITERADA", "ALUSION_INDIRECTA"}
+            for c in cats
+        ):
             score = min(score, 2.0)
         fam_top = max(contrib.items(), key=lambda kv: kv[1])[0] if contrib else "NINGUNO"
         concepto = "" if fam_top == "NINGUNO" else fam_top

--- a/coi_fraud/schemas.py
+++ b/coi_fraud/schemas.py
@@ -80,6 +80,7 @@ TX_COLS_EXPORT = [
     "feat_pair_month_count_ratio",
     "feat_pair_months_since_prev",
     "nlp_concepto_sospechoso",
+    "nlp_concepto_crudo",
     "feat_nlp_risk_points",
     "feat_nlp_vaguedad",
     "feat_nlp_emocion",

--- a/coi_fraud/text_utils.py
+++ b/coi_fraud/text_utils.py
@@ -1,0 +1,83 @@
+"""Utilidades de texto compartidas para normalizar conceptos crudos."""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any, Iterable
+
+import pandas as pd
+
+# Patrón de separación reutilizado al limpiar conceptos crudos.
+_CONCEPT_SPLIT_PATTERN = re.compile(r"[\s,;|/]+")
+
+# Codigos y expresiones que suelen acompañar referencias BNET u otros folios.
+_NOISE_TOKENS = {
+    "BNET",
+    "B-NET",
+    "B_NET",
+    "BN",
+    "BNTA",
+    "PAY",
+}
+_NOISE_PATTERN = re.compile(r"^(?:N\d{2,}|ID\d{2,}|FOLIO\d{2,}|REF\d{2,}|OP\d{2,}|TRX\d{2,})$")
+
+
+def clean_raw_concept(value: Any) -> str:
+    """Limpia un concepto libre eliminando prefijos/códigos comunes.
+
+    Ante cualquier error se devuelve el texto original para garantizar
+    robustez, cumpliendo el requerimiento de resiliencia a fallos.
+    """
+
+    original = "" if value is None else str(value)
+    try:
+        text = original.strip()
+        if not text or text.lower() == "nan":
+            return ""
+        cleaned_tokens: list[str] = []
+        for token in _CONCEPT_SPLIT_PATTERN.split(text):
+            token = token.strip()
+            if not token:
+                continue
+            normalized = re.sub(r"[^A-Z0-9]", "", token.upper())
+            if not normalized:
+                continue
+            if normalized in _NOISE_TOKENS:
+                continue
+            if _NOISE_PATTERN.fullmatch(normalized):
+                continue
+            cleaned_tokens.append(token)
+        cleaned = " ".join(cleaned_tokens).strip()
+        return cleaned if cleaned else original
+    except Exception:
+        return original
+
+
+def normalize_clean_concept(value: Any) -> str:
+    """Normaliza un concepto crudo limpiando ruido y homogenizando el texto."""
+
+    cleaned = clean_raw_concept(value)
+    if not cleaned:
+        return ""
+    text = unicodedata.normalize("NFKD", cleaned)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", " ", text).strip()
+    return text
+
+
+def first_non_empty_series(df: pd.DataFrame, columns: Iterable[str]) -> pd.Series:
+    """Devuelve la primera columna no vacía por fila como serie de strings."""
+
+    if df.empty:
+        return pd.Series([], index=df.index, dtype="string")
+    result = pd.Series([""] * len(df), index=df.index, dtype="string")
+    for col in columns:
+        if col not in df:
+            continue
+        candidate = df[col].fillna("").astype(str).str.strip()
+        candidate = candidate.mask(candidate.str.fullmatch(r"(?i)nan"), "")
+        mask = result.str.len() == 0
+        if mask.any():
+            result.loc[mask] = candidate.loc[mask]
+    return result

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -24,6 +24,11 @@ from coi_fraud.schemas import (
     COL_RELATION,
     COL_SENDER_ID,
 )
+from coi_fraud.text_utils import (
+    clean_raw_concept,
+    first_non_empty_series,
+    normalize_clean_concept,
+)
 
 
 DEFAULT_TIMEFRAME = "todo_el_tiempo"
@@ -45,14 +50,18 @@ NLP_CATEGORIES = (
     "REEMBOLSO_DUDOSO",
     "PRESTAMO",
     "COI_RELACIONAL",
+    "AGASAJOS_SOCIALES",
+    "DETALLE_PERSONAL",
+    "COORDINACION_REITERADA",
+    "ALUSION_INDIRECTA",
 )
 NLP_CATEGORY_SYNONYMS = {
     "SOBORNO": ("SOBOR", "COIMA", "BRIBE", "COHECHO", "SWEETENER"),
     "FACILITACIÓN": ("FACILIT", "FACILITATION", "GRATIFICACIÓN", "FAST TRACK", "PRIORIDAD"),
     "OFUSCACIÓN": ("OFUSC", "OBFUS", "OCULT", "ENCUBR", "SIN FACTURA"),
-    "EXTORSIÓN": ("EXTORS", "EXTORT", "AMENAZ", "DERECHO DE PISO"),
-    "FAVORES SEXUALES": ("SEXUAL", "SEX", "ACOSO", "PRIVADO", "INTIMO"),
-    "REGALOS_LUJO": ("REGALO", "LUJO", "VIP", "PREMIUM", "SUITE"),
+    "EXTORSIÓN": ("EXTORS", "EXTORT", "AMENAZ", "DERECHO DE PISO", "COPERACION"),
+    "FAVORES SEXUALES": ("SEXUAL", "SEX", "ACOSO", "PRIVADO", "INTIMO", "TANGA", "TANGAS", "LENCER"),
+    "REGALOS_LUJO": ("REGALO", "LUJO", "VIP", "PREMIUM", "SUITE", "DETALLAZO"),
     "CONFLICTO_INTERES_FAMILIAR": ("FAMILIA", "PARENTE", "PAREJA", "ESPOS", "HIJO"),
     "VIATICOS_LUJOSOS": ("VIATIC", "HOTEL", "BUSINESS", "PRIMERA", "CINCO ESTRELLAS"),
     "FACTURACION_SIMULADA": ("FACTURA", "FANTASMA", "SIMULAD", "FACHADA"),
@@ -63,6 +72,10 @@ NLP_CATEGORY_SYNONYMS = {
     "REEMBOLSO_DUDOSO": ("REEMBOLSO", "VIÁTICO", "GASTO", "VARIOS"),
     "PRESTAMO": ("PRÉSTAM", "ADELAN", "ABONO", "ANTICIPO"),
     "COI_RELACIONAL": ("COMPADRE", "PRIMO", "FAMIL", "AMIGO"),
+    "AGASAJOS_SOCIALES": ("CERVEZA", "CHELA", "FIESTA", "TRAGO", "AFTER", "ANTRO", "KARAOKE"),
+    "DETALLE_PERSONAL": ("DETALLE", "DETALLITO", "REGALITO", "TE COMPRO", "TECOMPRA", "REGLO"),
+    "COORDINACION_REITERADA": ("LO DE AYER", "MISMA JUGADA", "MISMO TRATO", "COMO QUEDAMOS"),
+    "ALUSION_INDIRECTA": ("YA SABES", "LO PENDIENTE", "AQUELLO", "LO HABLADO"),
 }
 CONCEPT_SPLIT_PATTERN = re.compile(r"[\s,;|/]+")
 
@@ -200,6 +213,72 @@ def _tokenize_concepts(value: Any) -> Iterable[str]:
     return [token for token in tokens if token]
 
 
+def _combine_unique_texts(values: Iterable[Any]) -> str:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text or text.lower() == "nan":
+            continue
+        if text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return "; ".join(ordered)
+
+
+def _max_text_length(values: Iterable[Any]) -> int:
+    lengths = []
+    for value in values:
+        if value in (None, "", pd.NA):
+            continue
+        text = str(value).strip()
+        if not text or text.lower() == "nan":
+            continue
+        lengths.append(len(text))
+    return max(lengths, default=0)
+
+
+def _most_common_text(values: Iterable[Any]) -> str:
+    counts: dict[str, int] = {}
+    top_text = ""
+    top_count = 0
+    for value in values:
+        if value in (None, "", pd.NA):
+            continue
+        text = str(value).strip()
+        if not text or text.lower() == "nan":
+            continue
+        counts[text] = counts.get(text, 0) + 1
+        if counts[text] > top_count or (counts[text] == top_count and len(text) > len(top_text)):
+            top_text = text
+            top_count = counts[text]
+    return top_text
+
+
+def _ensure_raw_concept_column(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df.copy()
+    work = df.copy()
+    source = first_non_empty_series(
+        work,
+        [
+            "nlp_concepto_crudo",
+            "reference_number_trans_desc",
+            COL_DESCRIPTION,
+            "tx_tags",
+            "feat_reference_norm",
+            "reference_norm",
+            "nlp_concepto_sospechoso",
+        ],
+    )
+    if source.empty and not work.empty:
+        source = pd.Series([""] * len(work), index=work.index, dtype="string")
+    work["nlp_concepto_crudo"] = source.reindex(work.index, fill_value="").map(clean_raw_concept)
+    return work
+
+
 def _coalesce_text_column(df: pd.DataFrame, column: str) -> pd.Series:
     if column in df:
         return df[column].fillna("").astype(str)
@@ -213,6 +292,8 @@ def _manager_nlp_hits(
     work = _filter_manager_subordinate(tx)
     if work.empty:
         return work.iloc[0:0].copy()
+
+    work = _ensure_raw_concept_column(work)
 
     combined_text = (
         _coalesce_text_column(work, "nlp_concepto_sospechoso")
@@ -244,6 +325,7 @@ def _manager_nlp_hits(
             fallback["matched_category"] = fallback["nlp_concepto_sospechoso"].apply(
                 lambda value: next(iter(_tokenize_concepts(value)), "SOSPECHOSO")
             )
+            fallback = _ensure_raw_concept_column(fallback)
             return fallback
 
     return work.iloc[0:0].copy()
@@ -293,6 +375,7 @@ def question1_manager_nlp(
                 "manager_user_id",
                 "subordinado_user_id",
                 "nlp_concepto_sospechoso",
+                "nlp_concepto_crudo",
                 "tx_count",
                 "monto_total",
                 "interpretabilidad",
@@ -308,6 +391,7 @@ def question1_manager_nlp(
                 "manager_user_id",
                 "subordinado_user_id",
                 "nlp_concepto_sospechoso",
+                "nlp_concepto_crudo",
                 "tx_count",
                 "monto_total",
                 "interpretabilidad",
@@ -348,12 +432,14 @@ def question1_manager_nlp(
         .agg(
             tx_count=(COL_AMOUNT, "count"),
             monto_total=(COL_AMOUNT, "sum"),
+            nlp_concepto_crudo=("nlp_concepto_crudo", _combine_unique_texts),
         )
         .reset_index()
     )
     agg = agg.sort_values(["tx_count", "monto_total"], ascending=[False, False])
     agg["timeframe"] = timeframe
     agg = agg.rename(columns={"matched_category": "nlp_concepto_sospechoso"})
+    agg["nlp_concepto_crudo"] = agg["nlp_concepto_crudo"].fillna("")
     agg["interpretabilidad"] = agg.apply(
         lambda row: (
             f"En la ventana '{timeframe}', durante {row.get('month_id', 'sin_mes')} "
@@ -362,6 +448,11 @@ def question1_manager_nlp(
             f"{row.get('subordinado_user_id', 'sin_subordinado')} etiquetados como "
             f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
             f"{_format_float(row.get('monto_total', 0))} en monto total."
+            + (
+                f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
+                if str(row.get("nlp_concepto_crudo", "")).strip()
+                else ""
+            )
         ),
         axis=1,
     )
@@ -371,6 +462,7 @@ def question1_manager_nlp(
         "manager_user_id",
         "subordinado_user_id",
         "nlp_concepto_sospechoso",
+        "nlp_concepto_crudo",
         "tx_count",
         "monto_total",
         "interpretabilidad",
@@ -819,7 +911,7 @@ def question4_quid_negative_value_vs_load(
 
 
 def question5_reference_reuse(
-    reports: Mapping[str, Any], timeframe: str = DEFAULT_TIMEFRAME
+    reports: Mapping[str, Any], timeframe: str = DEFAULT_TIMEFRAME, include_raw_concept: bool = False
 ) -> pd.DataFrame:
     """Detecta reutilización sospechosa de referencias de pago en corto plazo.
 
@@ -830,6 +922,9 @@ def question5_reference_reuse(
         transacciones base.
     timeframe
         Ventana temporal seleccionada (``"todo_el_tiempo"`` por defecto).
+    include_raw_concept
+        Cuando es ``True`` agrega un análisis análogo de reutilización
+        usando conceptos crudos normalizados.
 
     Metodología
     -----------
@@ -843,6 +938,8 @@ def question5_reference_reuse(
        las referencias más frecuentes.
     5. Redacta interpretabilidad con detalles de pares y transacciones
        involucrados.
+    6. Si ``include_raw_concept`` es ``True``, replica el análisis para los
+       conceptos crudos limpiados de ruido textual.
 
     Returns
     -------
@@ -865,7 +962,21 @@ def question5_reference_reuse(
         "tx_count",
     ]
 
+    concept_summary_columns = [
+        "concepto_norm",
+        "concepto_crudo",
+        "concepto_len",
+        "first_ts",
+        "last_ts",
+        "days_range",
+        "n_pairs",
+        "pairs",
+        "tx_count",
+    ]
+
     summary_relajado = False
+    concept_summary_relajado = False
+    concept_summary_df = pd.DataFrame(columns=concept_summary_columns)
     if not summary.empty:
         filtered = summary.loc[summary.get("n_pairs", 0) > 1].copy()
         filtered = filtered.sort_values(
@@ -981,6 +1092,9 @@ def question5_reference_reuse(
         "risk_score",
     ]
 
+    concept_tx_columns = tx_columns + ["nlp_concepto_crudo", "concepto_norm"]
+    concept_tx_df = pd.DataFrame(columns=concept_tx_columns)
+
     if not tx.empty:
         involved_refs = summary_df["reference_norm"].dropna().unique().tolist()
         filtered_tx = tx.loc[tx.get("feat_reference_norm", "").isin(involved_refs)].copy()
@@ -1014,11 +1128,122 @@ def question5_reference_reuse(
     else:
         tx_df["interpretabilidad"] = pd.Series(dtype="object")
 
-    combined = pd.concat([summary_df, tx_df], ignore_index=True, sort=False)
+    if include_raw_concept and not base_tx.empty:
+        concept_source = _ensure_raw_concept_column(base_tx)
+        concept_source["nlp_concepto_crudo"] = concept_source["nlp_concepto_crudo"].fillna("").astype(str)
+        concept_source["concepto_norm"] = concept_source["nlp_concepto_crudo"].map(normalize_clean_concept)
+        concept_source = concept_source.loc[concept_source["concepto_norm"].str.len() > 0].copy()
+        if not concept_source.empty:
+            concept_source["pair_id"] = (
+                concept_source.get(COL_SENDER_ID, "").astype(str)
+                + "->"
+                + concept_source.get(COL_RECEIVER_ID, "").astype(str)
+            )
+            concept_source["fecha_hora_ts"] = pd.to_datetime(
+                concept_source.get("fecha_hora_ts"), errors="coerce"
+            )
+            concept_summary = (
+                concept_source.groupby("concepto_norm", observed=True)
+                .agg(
+                    concepto_crudo=("nlp_concepto_crudo", _most_common_text),
+                    concepto_len=("nlp_concepto_crudo", _max_text_length),
+                    first_ts=("fecha_hora_ts", "min"),
+                    last_ts=("fecha_hora_ts", "max"),
+                    n_pairs=("pair_id", "nunique"),
+                    pairs=("pair_id", lambda s: "; ".join(sorted(set(map(str, s))))),
+                    tx_count=(COL_AMOUNT, "count"),
+                )
+                .reset_index()
+            )
+            if not concept_summary.empty:
+                concept_summary["days_range"] = (
+                    concept_summary["last_ts"] - concept_summary["first_ts"]
+                ).dt.days.fillna(0)
+                strict_summary = concept_summary.loc[
+                    (concept_summary["n_pairs"] > 1)
+                    & (concept_summary["days_range"].fillna(0) <= 30)
+                ].copy()
+                if not strict_summary.empty:
+                    concept_summary_df = strict_summary
+                else:
+                    concept_summary_relajado = True
+                    concept_summary_df = concept_summary.sort_values(
+                        ["tx_count", "days_range"], ascending=[False, True]
+                    ).head(10)
+                if not concept_summary_df.empty:
+                    concept_summary_df["concepto_len"] = (
+                        concept_summary_df.get("concepto_len", 0).fillna(0).astype(int)
+                    )
+                    concept_summary_df["days_range"] = (
+                        concept_summary_df.get("days_range", 0).fillna(0).astype(int)
+                    )
+                    concept_summary_df["first_ts"] = concept_summary_df["first_ts"].dt.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    concept_summary_df["last_ts"] = concept_summary_df["last_ts"].dt.strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    concept_summary_df = concept_summary_df.reindex(columns=concept_summary_columns)
+                    involved_norms = concept_summary_df["concepto_norm"].dropna().unique().tolist()
+                    concept_filtered = concept_source.loc[
+                        concept_source["concepto_norm"].isin(involved_norms)
+                    ].copy()
+                    if not concept_filtered.empty:
+                        concept_filtered = concept_filtered.sort_values(
+                            ["concepto_norm", "fecha_hora_ts"], ascending=[True, True]
+                        )
+                        concept_tx_df = concept_filtered.reindex(columns=concept_tx_columns)
+
+    concept_summary_df["nivel_respuesta"] = "concepto"
+    concept_summary_df["timeframe"] = timeframe
+    if not concept_summary_df.empty:
+        concept_summary_df["interpretabilidad"] = concept_summary_df.apply(
+            lambda row: (
+                f"El concepto crudo '{_coalesce_str(row.get('concepto_crudo'), default='sin_concepto')}' se reutilizó "
+                f"en {int(row.get('n_pairs', 0))} pares dentro de {row.get('days_range', 0)} días, "
+                f"acumulando {int(row.get('tx_count', 0))} transacciones entre {row.get('first_ts', 'sin_fecha')} "
+                f"y {row.get('last_ts', 'sin_fecha')}."
+                + (
+                    " Se listan conceptos crudos frecuentes sin cumplir aún el criterio multi-par (modo relajado)."
+                    if concept_summary_relajado
+                    else ""
+                )
+            ),
+            axis=1,
+        )
+    else:
+        concept_summary_df["interpretabilidad"] = pd.Series(dtype="object")
+
+    concept_tx_df["nivel_respuesta"] = "transaccion_concepto"
+    concept_tx_df["timeframe"] = timeframe
+    if not concept_tx_df.empty:
+        concept_tx_df["interpretabilidad"] = concept_tx_df.apply(
+            lambda row: (
+                f"La transacción del {row.get('fecha_hora_ts', 'sin_fecha')} repitió el concepto crudo "
+                f"'{_coalesce_str(row.get('nlp_concepto_crudo'), default='sin_concepto')}' entre "
+                f"{_coalesce_str(row.get(COL_SENDER_ID), default='emisor_desconocido')} y "
+                f"{_coalesce_str(row.get(COL_RECEIVER_ID), default='receptor_desconocido')}, "
+                f"reforzando un posible patrón coordinado en '{timeframe}'."
+            ),
+            axis=1,
+        )
+    else:
+        concept_tx_df["interpretabilidad"] = pd.Series(dtype="object")
+
+    frames = [summary_df, tx_df]
+    if include_raw_concept:
+        frames.extend([concept_summary_df, concept_tx_df])
+    combined = pd.concat(frames, ignore_index=True, sort=False)
     ordered_cols = [
         "timeframe",
         "nivel_respuesta",
-    ] + [c for c in summary_columns + tx_columns if c in combined.columns]
+    ] + [
+        c
+        for c in summary_columns
+        + tx_columns
+        + (concept_summary_columns + ["concepto_norm", "nlp_concepto_crudo"] if include_raw_concept else [])
+        if c in combined.columns
+    ]
     ordered_cols = list(dict.fromkeys(ordered_cols)) + ["interpretabilidad"]
     return combined.reindex(columns=ordered_cols)
 


### PR DESCRIPTION
## Summary
- expand the MX NLP embedding training corpus with live transaction text and discover near-synonym segments per category
- use the embedding-derived hits to boost category scores while keeping similarity outputs aligned with the new centroid matrix

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dee4e107e4832c96272a834dbc8d19