### PR TITLE
Allow reversing direction for manager NLP question

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ El módulo `experiment_questions.py` genera respuestas tabulares para siete preg
 
 - **Q1 – Manager con conceptos NLP sospechosos** (`question1_manager_nlp`):
   - **Metodología:** filtra transacciones manager-subordinado en `reports["transaccion"][timeframe]`, concatena campos `nlp_concepto_sospechoso`, `descripcion` y `tx_tags`, y ejecuta coincidencias por expresiones regulares contra las categorías `("SOBORNO", "FACILITACIÓN", "OFUSCACIÓN", "EXTORSIÓN", "FAVORES SEXUALES")` y sus sinónimos (`NLP_CATEGORY_SYNONYMS`). Agrupa por mes, categoría detectada, manager y subordinado para resumir `tx_count` y `monto_total` y generar textos explicativos.
-  - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores).
+  - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores); `direction` (``"manager_a_subordinado"`` por defecto, o ``"subordinado_a_manager"`` para invertir el flujo).
   - **Visualización rápida:**
     ```python
     import matplotlib.pyplot as plt

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -6,7 +6,7 @@ import inspect
 import re
 from pathlib import Path
 from textwrap import fill
-from typing import Any, Callable, Dict, Iterable, Mapping
+from typing import Any, Callable, Dict, Iterable, Mapping, Literal
 
 try:  # pragma: no cover - dependencia opcional en tiempo de ejecución
     import pandas as pd
@@ -38,6 +38,10 @@ from coi_fraud.text_utils import (
 
 DEFAULT_TIMEFRAME = "todo_el_tiempo"
 DEFAULT_OUTPUT_DIR = Path("answers")
+QUESTION1_DIRECTIONS: tuple[str, str] = (
+    "manager_a_subordinado",
+    "subordinado_a_manager",
+)
 NLP_CATEGORIES = (
     "SOBORNO",
     "FACILITACIÓN",
@@ -415,6 +419,8 @@ def question1_manager_nlp(
     reports: Mapping[str, Any],
     timeframe: str = DEFAULT_TIMEFRAME,
     categories: Iterable[str] = NLP_CATEGORIES,
+    *,
+    direction: Literal[QUESTION1_DIRECTIONS] = "manager_a_subordinado",
 ) -> pd.DataFrame:
     """Detecta pagos sospechosos entre managers y subordinados usando etiquetas NLP.
 
@@ -429,6 +435,10 @@ def question1_manager_nlp(
     categories
         Categorías NLP que deben buscarse dentro de los campos de texto; por
         defecto se emplea :data:`NLP_CATEGORIES`.
+    direction
+        Orientación del flujo de pagos a priorizar. Acepta ``"manager_a_subordinado"``
+        (por defecto) para pagos enviados por managers y ``"subordinado_a_manager"``
+        para el sentido inverso.
 
     Metodología
     -----------
@@ -462,6 +472,15 @@ def question1_manager_nlp(
             ]
         )
 
+    direction = str(direction)
+    if direction not in QUESTION1_DIRECTIONS:
+        valid = "', '".join(QUESTION1_DIRECTIONS)
+        raise ValueError(
+            "direction debe ser uno de '{valid}', se recibió '{direction}'".format(
+                valid=valid, direction=direction
+            )
+        )
+
     hits = _manager_nlp_hits(tx, categories)
     if hits.empty:
         return pd.DataFrame(
@@ -478,11 +497,18 @@ def question1_manager_nlp(
             ]
         )
 
+    if direction == "manager_a_subordinado":
+        manager_source = COL_SENDER_ID
+        subordinate_source = COL_RECEIVER_ID
+    else:
+        manager_source = COL_RECEIVER_ID
+        subordinate_source = COL_SENDER_ID
+
     hits["manager_user_id"] = (
-        hits[COL_RECEIVER_ID].fillna("").astype(str).replace({"": pd.NA})
+        hits[manager_source].fillna("").astype(str).replace({"": pd.NA})
     )
     hits["subordinado_user_id"] = (
-        hits[COL_SENDER_ID].fillna("").astype(str).replace({"": pd.NA})
+        hits[subordinate_source].fillna("").astype(str).replace({"": pd.NA})
     )
     hits = hits.dropna(subset=["manager_user_id", "subordinado_user_id"])
     if hits.empty:
@@ -520,22 +546,38 @@ def question1_manager_nlp(
     agg["timeframe"] = timeframe
     agg = agg.rename(columns={"matched_category": "nlp_concepto_sospechoso"})
     agg["nlp_concepto_crudo"] = agg["nlp_concepto_crudo"].fillna("")
-    agg["interpretabilidad"] = agg.apply(
-        lambda row: (
-            f"En la ventana '{timeframe}', durante {row.get('month_id', 'sin_mes')} "
-            f"el manager {row.get('manager_user_id', 'sin_manager')} recibió "
-            f"{int(row.get('tx_count', 0))} pagos del subordinado "
-            f"{row.get('subordinado_user_id', 'sin_subordinado')} etiquetados como "
-            f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
-            f"{_format_float(row.get('monto_total', 0))} en monto total."
-            + (
-                f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
-                if str(row.get("nlp_concepto_crudo", "")).strip()
-                else ""
+    if direction == "manager_a_subordinado":
+        def _build_message(row: pd.Series) -> str:
+            return (
+                f"En la ventana '{timeframe}', durante {row.get('month_id', 'sin_mes')} "
+                f"el manager {row.get('manager_user_id', 'sin_manager')} envió "
+                f"{int(row.get('tx_count', 0))} pagos al subordinado "
+                f"{row.get('subordinado_user_id', 'sin_subordinado')} etiquetados como "
+                f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
+                f"{_format_float(row.get('monto_total', 0))} en monto total."
+                + (
+                    f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
+                    if str(row.get('nlp_concepto_crudo', '')).strip()
+                    else ""
+                )
             )
-        ),
-        axis=1,
-    )
+    else:
+        def _build_message(row: pd.Series) -> str:
+            return (
+                f"En la ventana '{timeframe}', durante {row.get('month_id', 'sin_mes')} "
+                f"el subordinado {row.get('subordinado_user_id', 'sin_subordinado')} envió "
+                f"{int(row.get('tx_count', 0))} pagos al manager "
+                f"{row.get('manager_user_id', 'sin_manager')} etiquetados como "
+                f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
+                f"{_format_float(row.get('monto_total', 0))} en monto total."
+                + (
+                    f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
+                    if str(row.get('nlp_concepto_crudo', '')).strip()
+                    else ""
+                )
+            )
+
+    agg["interpretabilidad"] = agg.apply(_build_message, axis=1)
     columns = [
         "timeframe",
         "month_id",

--- a/experiment_visualizations.py
+++ b/experiment_visualizations.py
@@ -14,6 +14,7 @@ from matplotlib.axes import Axes
 from coi_fraud.schemas import COL_RECEIVER_ID, COL_SENDER_ID
 from experiment_questions import (
     DEFAULT_TIMEFRAME,
+    QUESTION1_DIRECTIONS,
     QUESTION_METADATA,
     question1_manager_nlp,
     question2_manager_concepts,
@@ -91,9 +92,10 @@ def plot_q1_manager_nlp(
     *,
     ax: Optional[Axes] = None,
     top_n: int = 10,
+    direction: str = "manager_a_subordinado",
 ) -> Axes:
     """Grafica los pares manager-subordinado con conceptos NLP sospechosos."""
-    data = question1_manager_nlp(reports, timeframe)
+    data = question1_manager_nlp(reports, timeframe, direction=direction)
     axis = _ensure_axis(ax)
     if data.empty:
         return _render_empty_chart(
@@ -104,17 +106,31 @@ def plot_q1_manager_nlp(
         )
 
     work = data.copy()
-    work["pair"] = (
-        work["manager_user_id"].fillna("sin_manager").astype(str)
-        + "→"
-        + work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
-    )
+    if direction == "manager_a_subordinado":
+        arrow = "→"
+        y_label = "Manager → Subordinado"
+        left = work["manager_user_id"].fillna("sin_manager").astype(str)
+        right = work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
+    elif direction == "subordinado_a_manager":
+        arrow = "→"
+        y_label = "Subordinado → Manager"
+        left = work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
+        right = work["manager_user_id"].fillna("sin_manager").astype(str)
+    else:
+        valid = "', '".join(QUESTION1_DIRECTIONS)
+        raise ValueError(
+            "direction debe ser uno de '{valid}', se recibió '{direction}'".format(
+                valid=valid, direction=direction
+            )
+        )
+
+    work["pair"] = left + arrow + right
     work = work.sort_values(["tx_count", "monto_total"], ascending=[False, False]).head(top_n)
 
     sns.barplot(data=work, x="tx_count", y="pair", hue="nlp_concepto_sospechoso", ax=axis)
     _apply_plot_metadata(axis, "q1_manager_nlp", timeframe)
     axis.set_xlabel("Número de transacciones")
-    axis.set_ylabel("Manager → Subordinado")
+    axis.set_ylabel(y_label)
     axis.legend(title="Concepto")
     return axis
 


### PR DESCRIPTION
## Summary
- add a direction parameter to `question1_manager_nlp` so the query can focus on manager-to-subordinate or the inverse flow
- propagate the new option to the Q1 visualization helper and document it in the README

## Testing
- python -m compileall experiment_questions.py experiment_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68deeb2bed78832cbfb4a446ede164f1