### PR TITLE
Add direction parameter to manager NLP question

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,19 @@ El módulo `experiment_questions.py` genera respuestas tabulares para siete preg
 
 - **Q1 – Manager con conceptos NLP sospechosos** (`question1_manager_nlp`):
   - **Metodología:** filtra transacciones manager-subordinado en `reports["transaccion"][timeframe]`, concatena campos `nlp_concepto_sospechoso`, `descripcion` y `tx_tags`, y ejecuta coincidencias por expresiones regulares contra las categorías `("SOBORNO", "FACILITACIÓN", "OFUSCACIÓN", "EXTORSIÓN", "FAVORES SEXUALES")` y sus sinónimos (`NLP_CATEGORY_SYNONYMS`). Agrupa por mes, categoría detectada, manager y subordinado para resumir `tx_count` y `monto_total` y generar textos explicativos.
-  - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores).
+  - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores); `direction` (``"manager_a_subordinado"`` por defecto, o ``"subordinado_a_manager"`` para invertir el flujo analizado).
   - **Visualización rápida:**
     ```python
     import matplotlib.pyplot as plt
     from experiment_visualizations import plot_q1_manager_nlp
 
     fig, ax = plt.subplots(figsize=(8, 5))
-    plot_q1_manager_nlp(reports, timeframe="todo_el_tiempo", ax=ax)
+    plot_q1_manager_nlp(
+        reports,
+        timeframe="todo_el_tiempo",
+        ax=ax,
+        direction="subordinado_a_manager",  # opcional: invierte el sentido
+    )
     plt.tight_layout()
     plt.show()
     ```

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -6,7 +6,7 @@ import inspect
 import re
 from pathlib import Path
 from textwrap import fill
-from typing import Any, Callable, Dict, Iterable, Mapping
+from typing import Any, Callable, Dict, Iterable, Mapping, Literal
 
 try:  # pragma: no cover - dependencia opcional en tiempo de ejecución
     import pandas as pd
@@ -411,10 +411,14 @@ def _manager_nlp_hits(
     return work.iloc[0:0].copy()
 
 
+DirectionOption = Literal["manager_a_subordinado", "subordinado_a_manager"]
+
+
 def question1_manager_nlp(
     reports: Mapping[str, Any],
     timeframe: str = DEFAULT_TIMEFRAME,
     categories: Iterable[str] = NLP_CATEGORIES,
+    direction: DirectionOption = "manager_a_subordinado",
 ) -> pd.DataFrame:
     """Detecta pagos sospechosos entre managers y subordinados usando etiquetas NLP.
 
@@ -429,6 +433,10 @@ def question1_manager_nlp(
     categories
         Categorías NLP que deben buscarse dentro de los campos de texto; por
         defecto se emplea :data:`NLP_CATEGORIES`.
+    direction
+        Define el sentido del flujo analizado. Usa ``"manager_a_subordinado"``
+        (valor predeterminado) para detectar pagos desde managers hacia sus
+        subordinados o ``"subordinado_a_manager"`` para invertir el análisis.
 
     Metodología
     -----------
@@ -462,6 +470,11 @@ def question1_manager_nlp(
             ]
         )
 
+    if direction not in ("manager_a_subordinado", "subordinado_a_manager"):
+        raise ValueError(
+            "direction debe ser 'manager_a_subordinado' o 'subordinado_a_manager'"
+        )
+
     hits = _manager_nlp_hits(tx, categories)
     if hits.empty:
         return pd.DataFrame(
@@ -478,11 +491,16 @@ def question1_manager_nlp(
             ]
         )
 
+    manager_col = COL_SENDER_ID if direction == "manager_a_subordinado" else COL_RECEIVER_ID
+    subordinado_col = (
+        COL_RECEIVER_ID if direction == "manager_a_subordinado" else COL_SENDER_ID
+    )
+
     hits["manager_user_id"] = (
-        hits[COL_RECEIVER_ID].fillna("").astype(str).replace({"": pd.NA})
+        hits[manager_col].fillna("").astype(str).replace({"": pd.NA})
     )
     hits["subordinado_user_id"] = (
-        hits[COL_SENDER_ID].fillna("").astype(str).replace({"": pd.NA})
+        hits[subordinado_col].fillna("").astype(str).replace({"": pd.NA})
     )
     hits = hits.dropna(subset=["manager_user_id", "subordinado_user_id"])
     if hits.empty:
@@ -493,6 +511,7 @@ def question1_manager_nlp(
                 "manager_user_id",
                 "subordinado_user_id",
                 "nlp_concepto_sospechoso",
+                "nlp_concepto_crudo",
                 "tx_count",
                 "monto_total",
                 "interpretabilidad",
@@ -520,22 +539,31 @@ def question1_manager_nlp(
     agg["timeframe"] = timeframe
     agg = agg.rename(columns={"matched_category": "nlp_concepto_sospechoso"})
     agg["nlp_concepto_crudo"] = agg["nlp_concepto_crudo"].fillna("")
-    agg["interpretabilidad"] = agg.apply(
-        lambda row: (
+    def _build_interpretability(row: pd.Series) -> str:
+        base = (
             f"En la ventana '{timeframe}', durante {row.get('month_id', 'sin_mes')} "
-            f"el manager {row.get('manager_user_id', 'sin_manager')} recibió "
-            f"{int(row.get('tx_count', 0))} pagos del subordinado "
-            f"{row.get('subordinado_user_id', 'sin_subordinado')} etiquetados como "
-            f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
-            f"{_format_float(row.get('monto_total', 0))} en monto total."
-            + (
-                f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
-                if str(row.get("nlp_concepto_crudo", "")).strip()
-                else ""
+            f"el manager {row.get('manager_user_id', 'sin_manager')} "
+        )
+        if direction == "manager_a_subordinado":
+            base += (
+                f"envió {int(row.get('tx_count', 0))} pagos al subordinado "
+                f"{row.get('subordinado_user_id', 'sin_subordinado')}"
             )
-        ),
-        axis=1,
-    )
+        else:
+            base += (
+                f"recibió {int(row.get('tx_count', 0))} pagos del subordinado "
+                f"{row.get('subordinado_user_id', 'sin_subordinado')}"
+            )
+        base += (
+            f" etiquetados como '{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}',"
+            f" acumulando {_format_float(row.get('monto_total', 0))} en monto total."
+        )
+        raw = str(row.get("nlp_concepto_crudo", "")).strip()
+        if raw:
+            base += f" Conceptos crudos detectados: {raw}."
+        return base
+
+    agg["interpretabilidad"] = agg.apply(_build_interpretability, axis=1)
     columns = [
         "timeframe",
         "month_id",

--- a/experiment_visualizations.py
+++ b/experiment_visualizations.py
@@ -15,6 +15,7 @@ from coi_fraud.schemas import COL_RECEIVER_ID, COL_SENDER_ID
 from experiment_questions import (
     DEFAULT_TIMEFRAME,
     QUESTION_METADATA,
+    DirectionOption,
     question1_manager_nlp,
     question2_manager_concepts,
     question3_quid_pairs,
@@ -91,9 +92,10 @@ def plot_q1_manager_nlp(
     *,
     ax: Optional[Axes] = None,
     top_n: int = 10,
+    direction: DirectionOption = "manager_a_subordinado",
 ) -> Axes:
     """Grafica los pares manager-subordinado con conceptos NLP sospechosos."""
-    data = question1_manager_nlp(reports, timeframe)
+    data = question1_manager_nlp(reports, timeframe, direction=direction)
     axis = _ensure_axis(ax)
     if data.empty:
         return _render_empty_chart(
@@ -104,17 +106,26 @@ def plot_q1_manager_nlp(
         )
 
     work = data.copy()
-    work["pair"] = (
-        work["manager_user_id"].fillna("sin_manager").astype(str)
-        + "→"
-        + work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
-    )
+    if direction == "manager_a_subordinado":
+        work["pair"] = (
+            work["manager_user_id"].fillna("sin_manager").astype(str)
+            + "→"
+            + work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
+        )
+        ylabel = "Manager → Subordinado"
+    else:
+        work["pair"] = (
+            work["subordinado_user_id"].fillna("sin_subordinado").astype(str)
+            + "→"
+            + work["manager_user_id"].fillna("sin_manager").astype(str)
+        )
+        ylabel = "Subordinado → Manager"
     work = work.sort_values(["tx_count", "monto_total"], ascending=[False, False]).head(top_n)
 
     sns.barplot(data=work, x="tx_count", y="pair", hue="nlp_concepto_sospechoso", ax=axis)
     _apply_plot_metadata(axis, "q1_manager_nlp", timeframe)
     axis.set_xlabel("Número de transacciones")
-    axis.set_ylabel("Manager → Subordinado")
+    axis.set_ylabel(ylabel)
     axis.legend(title="Concepto")
     return axis
 


### PR DESCRIPTION
## Summary
- allow question1_manager_nlp to analyse either manager→subordinado or subordinado→manager flows via a new `direction` parameter
- propagate the new direction option to the plot helper and documentation, including adjusted interpretability messages

## Testing
- python -m compileall experiment_questions.py experiment_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68deeb2bed78832cbfb4a446ede164f1