### PR TITLE
Update manager NLP aggregation and visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ dataset = generate_diverse_dataset()  # 6 000 filas por defecto
 El módulo `experiment_questions.py` genera respuestas tabulares para siete preguntas recurrentes a partir del diccionario de `reports` producido por `run_pipeline`. Todas las funciones aceptan `timeframe` (por defecto `"todo_el_tiempo"`) y devuelven columnas de interpretabilidad en español listando la lógica aplicada.
 
 - **Q1 – Manager con conceptos NLP sospechosos** (`question1_manager_nlp`):
-  - **Metodología:** filtra transacciones manager-subordinado en `reports["transaccion"][timeframe]`, concatena campos `nlp_concepto_sospechoso`, `descripcion` y `tx_tags`, y ejecuta coincidencias por expresiones regulares contra las categorías `("SOBORNO", "FACILITACIÓN", "OFUSCACIÓN", "EXTORSIÓN", "FAVORES SEXUALES")` y sus sinónimos (`NLP_CATEGORY_SYNONYMS`). Agrupa por mes, categoría detectada, manager y subordinado para resumir `tx_count` y `monto_total` y generar textos explicativos.
+  - **Metodología:** filtra transacciones manager-subordinado en `reports["transaccion"][timeframe]`, concatena campos `nlp_concepto_sospechoso`, `descripcion` y `tx_tags`, y ejecuta coincidencias por expresiones regulares contra las categorías `("SOBORNO", "FACILITACIÓN", "OFUSCACIÓN", "EXTORSIÓN", "FAVORES SEXUALES")` y sus sinónimos (`NLP_CATEGORY_SYNONYMS`). Agrupa por mes y par jerárquico, sumando `tx_count`, `monto_total` y recopilando en una lista todos los conceptos detectados para construir textos explicativos.
   - **Parámetros clave:** `timeframe`; `categories` (lista de categorías NLP, por defecto las cinco anteriores); `direction` (``"manager_a_subordinado"`` por defecto, o ``"subordinado_a_manager"`` para invertir el flujo).
   - **Visualización rápida:**
     ```python
@@ -187,6 +187,8 @@ El módulo `experiment_questions.py` genera respuestas tabulares para siete preg
     plt.tight_layout()
     plt.show()
     ```
+    Para invertir rápidamente la dirección mostrada basta con indicar
+    `invert_direction=True` al invocar la función de visualización.
 
 - **Q2 – Conceptos NLP con mayor severidad** (`question2_manager_concepts`):
   - **Metodología:** reutiliza la detección de Q1 sobre `reports["transaccion"][timeframe]` y agrega por mes y categoría calculando número de transacciones y el cuantil 0.95 de `risk_score`, ordenando por severidad antes de redactar la explicación.

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -237,6 +237,21 @@ def _combine_unique_texts(values: Iterable[Any]) -> str:
     return "; ".join(ordered)
 
 
+def _combine_unique_categories(values: Iterable[Any]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in (None, "", pd.NA):
+            continue
+        text = str(value).strip()
+        if not text or text.lower() == "nan":
+            continue
+        if text not in seen:
+            seen.add(text)
+            ordered.append(text)
+    return ordered
+
+
 def _max_text_length(values: Iterable[Any]) -> int:
     lengths = []
     for value in values:
@@ -447,15 +462,18 @@ def question1_manager_nlp(
        subordinado según las categorías proporcionadas y sus sinónimos.
     3. Normaliza identificadores de manager y subordinado y descarta registros
        incompletos.
-    4. Agrega conteos y montos por mes, categoría y par jerárquico, conservando
-       los conceptos crudos y las descripciones de origen para construir la
-       explicación en lenguaje natural.
+    4. Agrega conteos y montos por mes y par jerárquico, consolidando todas las
+       categorías detectadas en una lista junto con los conceptos crudos y las
+       descripciones de origen para construir la explicación en lenguaje
+       natural.
 
     Returns
     -------
     pandas.DataFrame
         Tabla priorizada con columnas de interpretabilidad sobre conceptos NLP
-        sospechosos en relaciones manager-subordinado.
+        sospechosos en relaciones manager-subordinado. La columna
+        ``"nlp_concepto_sospechoso"`` contiene una lista de conceptos únicos
+        detectados para cada par y periodo.
     """
     tx = _get_section(reports, "transaccion", timeframe)
     if tx.empty:
@@ -534,6 +552,10 @@ def question1_manager_nlp(
         "tx_count": (COL_AMOUNT, "count"),
         "monto_total": (COL_AMOUNT, "sum"),
         "nlp_concepto_crudo": ("nlp_concepto_crudo", _combine_unique_texts),
+        "nlp_concepto_sospechoso": (
+            "matched_category",
+            _combine_unique_categories,
+        ),
     }
     if COL_DESCRIPTION in hits.columns:
         aggregations["nlp_descripciones"] = (
@@ -549,12 +571,7 @@ def question1_manager_nlp(
 
     agg = (
         hits.groupby(
-            [
-                "month_id",
-                "matched_category",
-                "manager_user_id",
-                "subordinado_user_id",
-            ],
+            ["month_id", "manager_user_id", "subordinado_user_id"],
             observed=True,
         )
         .agg(**aggregations)
@@ -562,10 +579,15 @@ def question1_manager_nlp(
     )
     agg = agg.sort_values(["tx_count", "monto_total"], ascending=[False, False])
     agg["timeframe"] = timeframe
-    agg = agg.rename(columns={"matched_category": "nlp_concepto_sospechoso"})
     agg["nlp_concepto_crudo"] = agg["nlp_concepto_crudo"].fillna("")
     if "nlp_descripciones" in agg:
         agg["nlp_descripciones"] = agg["nlp_descripciones"].fillna("")
+    agg["nlp_concepto_sospechoso"] = agg["nlp_concepto_sospechoso"].apply(
+        lambda values: values if isinstance(values, list) else []
+    )
+    agg["_concepto_label"] = agg["nlp_concepto_sospechoso"].apply(
+        lambda values: ", ".join(values) if values else "SIN_CONCEPTO"
+    )
     if direction == "manager_a_subordinado":
         def _build_message(row: pd.Series) -> str:
             return (
@@ -573,7 +595,7 @@ def question1_manager_nlp(
                 f"el manager {row.get('manager_user_id', 'sin_manager')} envió "
                 f"{int(row.get('tx_count', 0))} pagos al subordinado "
                 f"{row.get('subordinado_user_id', 'sin_subordinado')} etiquetados como "
-                f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
+                f"'{row.get('_concepto_label', 'SIN_CONCEPTO')}', acumulando "
                 f"{_format_float(row.get('monto_total', 0))} en monto total."
                 + (
                     f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
@@ -593,7 +615,7 @@ def question1_manager_nlp(
                 f"el subordinado {row.get('subordinado_user_id', 'sin_subordinado')} envió "
                 f"{int(row.get('tx_count', 0))} pagos al manager "
                 f"{row.get('manager_user_id', 'sin_manager')} etiquetados como "
-                f"'{row.get('nlp_concepto_sospechoso', 'SIN_CONCEPTO')}', acumulando "
+                f"'{row.get('_concepto_label', 'SIN_CONCEPTO')}', acumulando "
                 f"{_format_float(row.get('monto_total', 0))} en monto total."
                 + (
                     f" Conceptos crudos detectados: {row.get('nlp_concepto_crudo', '').strip()}."
@@ -608,6 +630,7 @@ def question1_manager_nlp(
             )
 
     agg["interpretabilidad"] = agg.apply(_build_message, axis=1)
+    agg = agg.drop(columns=["_concepto_label"])
     columns = [
         "timeframe",
         "month_id",

--- a/experiment_visualizations.py
+++ b/experiment_visualizations.py
@@ -93,8 +93,43 @@ def plot_q1_manager_nlp(
     ax: Optional[Axes] = None,
     top_n: int = 10,
     direction: str = "manager_a_subordinado",
+    invert_direction: bool = False,
 ) -> Axes:
-    """Grafica los pares manager-subordinado con conceptos NLP sospechosos."""
+    """Grafica los pares manager-subordinado con conceptos NLP sospechosos.
+
+    Parameters
+    ----------
+    reports
+        Salidas tabulares del pipeline de detección de fraude.
+    timeframe
+        Ventana temporal a consultar.
+    ax
+        Eje de Matplotlib donde dibujar la gráfica.
+    top_n
+        Número máximo de pares a mostrar.
+    direction
+        Dirección inicial del flujo de pagos a visualizar. Acepta
+        ``"manager_a_subordinado"`` o ``"subordinado_a_manager"``.
+    invert_direction
+        Cuando es ``True`` invierte el flujo indicado en ``direction`` para
+        permitir la visualización del sentido contrario sin necesidad de
+        recalcular la tabla previa.
+    """
+    direction = str(direction)
+    if direction not in QUESTION1_DIRECTIONS:
+        valid = "', '".join(QUESTION1_DIRECTIONS)
+        raise ValueError(
+            "direction debe ser uno de '{valid}', se recibió '{direction}'".format(
+                valid=valid, direction=direction
+            )
+        )
+    if invert_direction:
+        direction = (
+            "subordinado_a_manager"
+            if direction == "manager_a_subordinado"
+            else "manager_a_subordinado"
+        )
+
     data = question1_manager_nlp(reports, timeframe, direction=direction)
     axis = _ensure_axis(ax)
     if data.empty:
@@ -106,6 +141,9 @@ def plot_q1_manager_nlp(
         )
 
     work = data.copy()
+    work["concepto_label"] = work["nlp_concepto_sospechoso"].apply(
+        lambda values: ", ".join(values) if isinstance(values, list) and values else "SIN_CONCEPTO"
+    )
     if direction == "manager_a_subordinado":
         arrow = "→"
         y_label = "Manager → Subordinado"
@@ -127,11 +165,13 @@ def plot_q1_manager_nlp(
     work["pair"] = left + arrow + right
     work = work.sort_values(["tx_count", "monto_total"], ascending=[False, False]).head(top_n)
 
-    sns.barplot(data=work, x="tx_count", y="pair", hue="nlp_concepto_sospechoso", ax=axis)
+    sns.barplot(data=work, x="tx_count", y="pair", hue="concepto_label", ax=axis)
     _apply_plot_metadata(axis, "q1_manager_nlp", timeframe)
     axis.set_xlabel("Número de transacciones")
     axis.set_ylabel(y_label)
-    axis.legend(title="Concepto")
+    legend = axis.get_legend()
+    if legend is not None:
+        legend.set_title("Concepto")
     return axis
 
 


### PR DESCRIPTION
## Summary
- collect all matched NLP categories per manager-subordinate pair in `question1_manager_nlp`, returning them as lists and updating the interpretability message
- document the new behavior in the README and refresh the helper text about the visualization
- adapt `plot_q1_manager_nlp` to the list-based output and add an option to invert the payment direction

## Testing
- python -m compileall experiment_questions.py experiment_visualizations.py

------
https://chatgpt.com/codex/tasks/task_e_68df172b4414832cb03a927ad71bf87b