### PR TITLE
Align Q18 risk scoring with updated flag weights

### DIFF
--- a/docs/question18_scoring.md
+++ b/docs/question18_scoring.md
@@ -16,28 +16,30 @@ Los cortes entre niveles usan percentiles sobre la métrica primaria de cada cas
    * Texto interpretativo por casuística.
 2. Tras normalizar, se ejecuta `_score_metric_series` sobre la métrica principal de la casuística. El helper convierte la serie en numérica, calcula los percentiles relevantes y asigna el score 3/2/1. Los valores ausentes o ≤0 reciben 1.
 3. Se almacena para cada casuística el score, el tier (`Alto`, `Medio`, `Bajo`) y un detalle textual breve que se usa tanto en columnas individuales como en la explicación consolidada.
-4. Se definen pesos relativos por casuística (ver tabla) y se calcula `casuistica_score_total = Σ (score_i × peso_i)` junto con `casuistica_score_promedio` normalizado por la suma de pesos.
+4. Se definen pesos relativos por casuística (ver tabla) en una escala de 1–10 alineada a las banderas proporcionadas (rojas, alto riesgo, amarillas e indicadores de contexto). El cálculo del score ponderado usa `casuistica_score_total = Σ (score_i × peso_i)` junto con `casuistica_score_promedio` normalizado por la suma de pesos.
 5. El resumen `casuistica_resumen` recoge hasta tres casuísticas con score > 1 ordenadas por score y peso para mostrar en la interpretación principal.
-6. La priorización final ordena por `casuistica_score_total`, riesgo promedio, desbalance neto absoluto y banderas.
+6. Se generan columnas tipo `bandera_<casuistica>` que indican si la persona activa la casuística (`SIN_ALERTA` cuando el score es 1) y el color de bandera asociado.
+7. Se calcula `casuistica_score_total_todas_temporalidades` sumando los scores ponderados de cada persona en todas las ventanas disponibles del reporte, manteniendo también el detalle del timeframe actual.
+8. La priorización final ordena por `casuistica_score_total`, riesgo promedio, desbalance neto absoluto y banderas.
 
 ## Pesos y métricas por casuística
 
-| Casuística | Métrica primaria | Detalles agregados | Peso |
-| --- | --- | --- | --- |
-| NLP manager-subordinado | `tx_manager_nlp` (conteo total de pagos con etiquetas NLP) | Rol (manager/subordinado), conceptos detectados, monto total | 1.1 |
-| Conceptos NLP severos | Máximo `risk_p95` asociado a los conceptos de la persona | Conceptos coincidentes | 0.9 |
-| Quid pro quo | `tx_quid_pairs × max(quid_score)` | Contrapartes apareadas | 1.2 |
-| Valor vs. carga | Suma de `abs(delta días)` + `feat_quid_score` | Contrapartes y responsables | 1.0 |
-| Referencias reutilizadas | Total de transacciones con la referencia | Referencias normalizadas y contrapartes | 1.0 |
-| Centralizadores | `inflow` acumulado del receptor | Número de emisores únicos y pagos | 1.1 |
-| Desbalance neto | `|desbalance_persona_monto_neto|` | Meses extremos al enviar/recibir | 1.4 |
-| Caso 13 (receptores nuevos) | Monto total recibido | Tx y emisores únicos | 1.3 |
-| Caso 14 (veteranos desde nuevos) | Monto recibido desde emisores nuevos | Tx y emisores únicos | 1.2 |
-| Yo-yo | `tx_yo_yo_totales + racha_max + (riesgo_max - 1)` | Contrapartes en la racha | 1.0 |
-| Cercanía a umbral | `tx_near_totales + monto_total_near / 1000` | Contrapartes involucradas | 0.9 |
-| Fraccionamiento crónico | `transacciones_fraccionadas + monto_fraccionado_total / 1000` | Contrapartes | 1.4 |
-| Préstamos impagos | `monto_prestamos_incumplidos + 1000×prestamos + 500×eventos` | Contrapartes | 1.3 |
-| Pagos recurrentes tipo nómina | `monto_total + 1000×meses_recurrentes` | Contrapartes recurrentes | 1.2 |
+| Casuística | Bandera | Métrica primaria | Detalles agregados | Peso |
+| --- | --- | --- | --- | --- |
+| NLP manager-subordinado | Bandera roja | `tx_manager_nlp` (conteo total de pagos con etiquetas NLP) | Rol (manager/subordinado), conceptos detectados, monto total | 10 |
+| Conceptos NLP severos | Bandera roja | Máximo `risk_p95` asociado a los conceptos de la persona | Conceptos coincidentes | 9 |
+| Quid pro quo | Bandera roja | `tx_quid_pairs × max(quid_score)` | Contrapartes apareadas | 10 |
+| Valor vs. carga | Alto riesgo | Suma de `abs(delta días)` + `feat_quid_score` | Contrapartes y responsables | 8 |
+| Referencias reutilizadas | Alto riesgo | Total de transacciones con la referencia | Referencias normalizadas y contrapartes | 7 |
+| Centralizadores | Bandera amarilla | `inflow` acumulado del receptor | Número de emisores únicos y pagos | 7 |
+| Desbalance neto | Indicador de contexto | `|desbalance_persona_monto_neto|` | Meses extremos al enviar/recibir | 3 |
+| Caso 13 (receptores nuevos) | Bandera amarilla | Monto total recibido | Tx y emisores únicos | 6 |
+| Caso 14 (veteranos desde nuevos) | Bandera roja | Monto recibido desde emisores nuevos | Tx y emisores únicos | 9 |
+| Yo-yo | Alto riesgo | `tx_yo_yo_totales + racha_max + (riesgo_max - 1)` | Contrapartes en la racha | 8 |
+| Cercanía a umbral | Bandera amarilla | `tx_near_totales + monto_total_near / 1000` | Contrapartes involucradas | 6 |
+| Fraccionamiento crónico | Bandera roja | `transacciones_fraccionadas + monto_fraccionado_total / 1000` | Contrapartes | 9 |
+| Préstamos impagos | Alto riesgo | `monto_prestamos_incumplidos + 1000×prestamos + 500×eventos` | Contrapartes | 8 |
+| Pagos recurrentes tipo nómina | Alto riesgo | `monto_total + 1000×meses_recurrentes` | Contrapartes recurrentes | 8 |
 
 Las métricas monetarias se expresan como floats y se combinan con conteos para dar más peso a concentraciones relevantes. Cuando una métrica principal es cero o no hay registros, la persona obtiene score 1 (Bajo) en esa casuística.
 

--- a/experiment_questions.py
+++ b/experiment_questions.py
@@ -4921,7 +4921,11 @@ def question17_nlp_person_profiles(
 
 
 def question18_user_risk_scores(
-    reports: Mapping[str, Any], timeframe: str = DEFAULT_TIMEFRAME, top_n: int = 25
+    reports: Mapping[str, Any],
+    timeframe: str = DEFAULT_TIMEFRAME,
+    top_n: int | None = 25,
+    *,
+    include_all_timeframes_total: bool = True,
 ) -> pd.DataFrame:
     """Prioriza personas por riesgo promedio, desbalance y señales activas."""
 
@@ -6357,7 +6361,9 @@ def question18_user_risk_scores(
     scenario_metadata = {
         "manager_nlp": {
             "label": "NLP manager-subordinado",
-            "weight": 1.1,
+            "weight": 10.0,
+            "risk_rating": 10,
+            "flag_label": "BANDERA ROJA",
             "score_col": "score_manager_nlp",
             "tier_col": "tier_manager_nlp",
             "detail_col": "detalle_manager_nlp",
@@ -6375,7 +6381,9 @@ def question18_user_risk_scores(
         },
         "manager_concepts": {
             "label": "Conceptos NLP severos",
-            "weight": 0.9,
+            "weight": 9.0,
+            "risk_rating": 9,
+            "flag_label": "BANDERA ROJA",
             "score_col": "score_manager_concepts",
             "tier_col": "tier_manager_concepts",
             "detail_col": "detalle_manager_concepts",
@@ -6391,7 +6399,9 @@ def question18_user_risk_scores(
         },
         "quid_pairs": {
             "label": "Quid pro quo",
-            "weight": 1.2,
+            "weight": 10.0,
+            "risk_rating": 10,
+            "flag_label": "BANDERA ROJA",
             "score_col": "score_quid_pairs",
             "tier_col": "tier_quid_pairs",
             "detail_col": "detalle_quid_pairs",
@@ -6408,7 +6418,9 @@ def question18_user_risk_scores(
         },
         "quid_value_vs_load": {
             "label": "Valor vs carga",
-            "weight": 1.0,
+            "weight": 8.0,
+            "risk_rating": 8,
+            "flag_label": "ALTO RIESGO",
             "score_col": "score_quid_value_vs_load",
             "tier_col": "tier_quid_value_vs_load",
             "detail_col": "detalle_quid_value_vs_load",
@@ -6436,7 +6448,9 @@ def question18_user_risk_scores(
         },
         "reference_reuse": {
             "label": "Referencias reutilizadas",
-            "weight": 1.0,
+            "weight": 7.0,
+            "risk_rating": 7,
+            "flag_label": "ALTO RIESGO",
             "score_col": "score_reference_reuse",
             "tier_col": "tier_reference_reuse",
             "detail_col": "detalle_reference_reuse",
@@ -6457,7 +6471,9 @@ def question18_user_risk_scores(
         },
         "centralizer": {
             "label": "Centralizadores",
-            "weight": 1.1,
+            "weight": 7.0,
+            "risk_rating": 7,
+            "flag_label": "BANDERA AMARILLA",
             "score_col": "score_centralizer",
             "tier_col": "tier_centralizer",
             "detail_col": "detalle_centralizer",
@@ -6478,7 +6494,9 @@ def question18_user_risk_scores(
         },
         "net_imbalance": {
             "label": "Desbalance neto",
-            "weight": 1.4,
+            "weight": 3.0,
+            "risk_rating": 3,
+            "flag_label": "INDICADOR CONTEXTO",
             "score_col": "score_net_imbalance",
             "tier_col": "tier_net_imbalance",
             "detail_col": "detalle_net_imbalance",
@@ -6499,7 +6517,9 @@ def question18_user_risk_scores(
         },
         "case13": {
             "label": "Receptores nuevos (Caso 13)",
-            "weight": 1.3,
+            "weight": 6.0,
+            "risk_rating": 6,
+            "flag_label": "BANDERA AMARILLA",
             "score_col": "score_case13",
             "tier_col": "tier_case13",
             "detail_col": "detalle_case13",
@@ -6516,7 +6536,9 @@ def question18_user_risk_scores(
         },
         "case14": {
             "label": "Veteranos desde nuevos (Caso 14)",
-            "weight": 1.2,
+            "weight": 9.0,
+            "risk_rating": 9,
+            "flag_label": "BANDERA ROJA",
             "score_col": "score_case14",
             "tier_col": "tier_case14",
             "detail_col": "detalle_case14",
@@ -6533,7 +6555,9 @@ def question18_user_risk_scores(
         },
         "yoyo": {
             "label": "Rachas yo-yo",
-            "weight": 1.0,
+            "weight": 8.0,
+            "risk_rating": 8,
+            "flag_label": "ALTO RIESGO",
             "score_col": "score_yoyo",
             "tier_col": "tier_yoyo",
             "detail_col": "detalle_yoyo",
@@ -6551,7 +6575,9 @@ def question18_user_risk_scores(
         },
         "near_threshold": {
             "label": "Cercanía a umbral",
-            "weight": 0.9,
+            "weight": 6.0,
+            "risk_rating": 6,
+            "flag_label": "BANDERA AMARILLA",
             "score_col": "score_near_threshold",
             "tier_col": "tier_near_threshold",
             "detail_col": "detalle_near_threshold",
@@ -6573,7 +6599,9 @@ def question18_user_risk_scores(
         },
         "smurfing": {
             "label": "Fraccionamiento crónico",
-            "weight": 1.4,
+            "weight": 9.0,
+            "risk_rating": 9,
+            "flag_label": "BANDERA ROJA",
             "score_col": "score_smurfing",
             "tier_col": "tier_smurfing",
             "detail_col": "detalle_smurfing",
@@ -6595,7 +6623,9 @@ def question18_user_risk_scores(
         },
         "bad_loans": {
             "label": "Préstamos impagos",
-            "weight": 1.3,
+            "weight": 8.0,
+            "risk_rating": 8,
+            "flag_label": "ALTO RIESGO",
             "score_col": "score_bad_loans",
             "tier_col": "tier_bad_loans",
             "detail_col": "detalle_bad_loans",
@@ -6619,7 +6649,9 @@ def question18_user_risk_scores(
         },
         "recurrent_payroll": {
             "label": "Pagos recurrentes",
-            "weight": 1.2,
+            "weight": 8.0,
+            "risk_rating": 8,
+            "flag_label": "ALTO RIESGO",
             "score_col": "score_recurrent_payroll",
             "tier_col": "tier_recurrent_payroll",
             "detail_col": "detalle_recurrent_payroll",
@@ -6644,6 +6676,7 @@ def question18_user_risk_scores(
     }
 
     scenario_columns_order: list[str] = []
+    flag_columns: list[str] = []
     for key, meta in scenario_metadata.items():
         scenario_df = scenario_frames.get(key, pd.DataFrame())
         expected_cols = ["persona"] + meta["columns"]
@@ -6669,11 +6702,24 @@ def question18_user_risk_scores(
         detail_col = meta.get("detail_col")
         if detail_col and detail_col in work.columns:
             work[detail_col] = work[detail_col].fillna("sin_detalle").astype(str)
+        flag_label = meta.get("flag_label")
+        risk_rating = meta.get("risk_rating")
+        flag_col = f"bandera_{key}"
+        flag_series = pd.Series("SIN_ALERTA", index=work.index, dtype="object")
+        if flag_label:
+            label_text = (
+                f"{flag_label} ({risk_rating})"
+                if risk_rating is not None
+                else str(flag_label)
+            )
+            flag_series.loc[work[score_col] > 1] = label_text
+        work[flag_col] = flag_series
+        flag_columns.append(flag_col)
         scenario_columns_order.extend(
             [col for col in meta["columns"] if col not in scenario_columns_order]
         )
 
-    total_weight = sum(item["weight"] for item in scenario_metadata.values())
+    total_weight = sum(float(item["weight"]) for item in scenario_metadata.values())
     work["casuistica_score_total"] = 0.0
     for meta in scenario_metadata.values():
         work["casuistica_score_total"] += work[meta["score_col"]] * meta["weight"]
@@ -6710,6 +6756,60 @@ def question18_user_risk_scores(
     for col in scenario_columns_order:
         if col not in columns:
             columns.append(col)
+    for col in flag_columns:
+        if col not in columns:
+            columns.append(col)
+
+    if include_all_timeframes_total:
+        persona_series = work.get("persona", pd.Series(dtype="object")).astype(str)
+        base_scores = pd.to_numeric(
+            work.get("casuistica_score_total", 0.0), errors="coerce"
+        ).fillna(0.0)
+        totals_map: dict[str, float] = {
+            persona: float(score)
+            for persona, score in zip(persona_series, base_scores)
+        }
+        persona_section = reports.get("persona") if isinstance(reports, Mapping) else None
+        timeframe_keys: Iterable[Any]
+        if isinstance(persona_section, Mapping):
+            timeframe_keys = persona_section.keys()
+        else:
+            timeframe_keys = []
+        seen_timeframes: set[str] = set()
+        current_key = str(timeframe)
+        for tf_candidate in timeframe_keys:
+            tf_key = str(tf_candidate)
+            if tf_key in seen_timeframes:
+                continue
+            seen_timeframes.add(tf_key)
+            if tf_key == current_key:
+                continue
+            tf_result = question18_user_risk_scores(
+                reports,
+                timeframe=tf_candidate,
+                top_n=None,
+                include_all_timeframes_total=False,
+            )
+            if tf_result.empty or "persona" not in tf_result.columns:
+                continue
+            if "casuistica_score_total" not in tf_result.columns:
+                continue
+            tf_scores = tf_result[["persona", "casuistica_score_total"]].copy()
+            tf_scores["persona"] = tf_scores["persona"].astype(str)
+            tf_scores["casuistica_score_total"] = pd.to_numeric(
+                tf_scores["casuistica_score_total"], errors="coerce"
+            ).fillna(0.0)
+            for persona, score in tf_scores.itertuples(index=False):
+                totals_map[persona] = totals_map.get(persona, 0.0) + float(score)
+        total_series = persona_series.map(totals_map).fillna(base_scores)
+        work["casuistica_score_total_todas_temporalidades"] = total_series.astype(float)
+    else:
+        work["casuistica_score_total_todas_temporalidades"] = pd.to_numeric(
+            work.get("casuistica_score_total", 0.0), errors="coerce"
+        ).fillna(0.0)
+
+    if "casuistica_score_total_todas_temporalidades" not in columns:
+        columns.append("casuistica_score_total_todas_temporalidades")
 
     flag_rate_cols = {
         "yo_yo_persona_tasa_flag_emisor": "yo-yo",
@@ -6779,7 +6879,18 @@ def question18_user_risk_scores(
             "flags_activas",
         ],
         ascending=[False, False, False, False, False],
-    ).head(max(1, int(top_n)))
+    )
+
+    if top_n is not None:
+        try:
+            top_limit = int(top_n)
+        except (TypeError, ValueError):
+            top_limit = 0
+        if top_limit <= 0:
+            limit = len(work)
+        else:
+            limit = max(1, top_limit)
+        work = work.head(limit)
     work["ranking_prioridad"] = list(range(1, len(work) + 1))
 
     def _direction(value: float) -> str:

--- a/tests/test_question18_user_risk_scores.py
+++ b/tests/test_question18_user_risk_scores.py
@@ -92,6 +92,13 @@ def test_question18_handles_alias_columns(monkeypatch):
         "sum_emit",
         "sum_recv",
         "banderas_destacadas",
+        "bandera_manager_nlp",
+        "casuistica_score_total_todas_temporalidades",
     }.issubset(result.columns)
+    assert (
+        persona_p1["casuistica_score_total_todas_temporalidades"]
+        == persona_p1["casuistica_score_total"]
+    )
+    assert persona_p1["bandera_manager_nlp"] == "SIN_ALERTA"
     detalle = persona_p1["detalle_pagos_mensuales"]
     assert isinstance(detalle, list) and len(detalle) == 1


### PR DESCRIPTION
## Summary
- map Q18 casuistics to the new flag categories with 1–10 weights and expose per-casuística flag columns
- add an aggregated `casuistica_score_total_todas_temporalidades` to combine scores across all timeframes and allow unbounded exports
- document the revised weighting scheme and extend the Q18 test to cover the new outputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f6c2f8f314832cbde40fc2fee207d0